### PR TITLE
Removed section 508 link

### DIFF
--- a/resources/accessible-web-pages-en.html
+++ b/resources/accessible-web-pages-en.html
@@ -53,9 +53,9 @@
             <li><a href="https://www.w3.org/WAI/fundamentals/accessibility-intro/">Introduction to Web Accessibility (A11Y)</a></li>
             <li><a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a></li>
             <li><a href="../resources/wcag-en.html">The structure of Web Content Accessibility Guidelines (WCAG) 2.1</a></li>
-            <li><a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=23601">Canadian Standards on Web AccessibilityEuropean Standards - EN 301 549</a></li>
-            <li><a href="https://www.section508.gov/">American Standards Section 508</a></li>
-            <li><a href="../resources/a11ycheck-en.html">Web Accessibility Checklist</a></li>
+            <li><a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=23601">Canadian Standards on Web Accessibility</a></li>
+            <li><a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf">European Standards - EN 301 549</a></li>
+            <li><a href="../resources/a11ycheck-en.html">Web Accessibility Checklist for ESDC development teams</a></li>
             </ul>
         <div id="def-preFooter"></div>
         <script src="../scripts/preFooter.min.js"></script>

--- a/resources/accessible-web-pages-fr.html
+++ b/resources/accessible-web-pages-fr.html
@@ -52,9 +52,9 @@
             <li><a href="https://www.w3.org/WAI/fundamentals/accessibility-intro/">Introduction à l’accessibilité du Web</a> (anglais seulement)</li>
             <li><a href="https://www.w3.org/TR/WCAG21/">Règles pour l’accessibilité des contenus Web (WCAG) 2.1</a> (anglais seulement)</li>
             <li><a href="../resources/wcag-fr.html">La structure des règles pour l’accessibilité des contenus Web (WCAG) 2.1</a></li>
-            <li><a href="https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=23601">Normes canadiennes sur l’accessibilité des sites Web Normes européennes - EN 301 549</a></li>
-            <li><a href="https://www.section508.gov/">Normes américaines Section 508</a> (anglais seulement)</li>
-            <li><a href="../resources/a11ycheck-fr.html">Liste de vérification pour l’accessibilité Web</a></li>
+            <li><a href="https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=23601">Normes canadiennes sur l’accessibilité des sites Web</a></li>
+            <li><a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf">Normes européennes - EN 301 549 (anglais seulement)</a></li>
+            <li><a href="../resources/a11ycheck-fr.html">Liste de vérification de l’accessibilité Web pour les équipes de développement d'EDSC</a></li>
             </ul>
 
         <div id="def-preFooter"></div>


### PR DESCRIPTION
- Removed Section 508 link
- Fixed “Canadian Standards on Web Accessibility” and “European Standards – EN 301 549” are on the same line
- Updated “Web Accessibility Checklist” to “Web accessibility checklist for ESDC development teams”