### PR TITLE
example headings and code blocks

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/content-structure.html
+++ b/learning/esdc-self-paced-web-accessibility-course/content-structure.html
@@ -88,10 +88,10 @@
 			<section aria-label="Articles">
 				<h2 id="articles">Articles</h2>
 				<p>The HTML5 <code>&lt;article&gt;</code> element represents a complete or self-contained composition in a web page. Examples of articles include an item at a shopping site or a news article on a news site.</p>
-				<h3 id="">Code Snippet</h3>
+				
 				 <span class="wb-prettify"></span>
 <pre>
- <code class=‚Äùlanguage-html‚Äù>&lt;article&gt; 
+ <code class="ùlanguage-html"ù>&lt;article&gt; 
 	&lt;h2&gt;Tooth Paste Classic&lt;/h2&gt;
 &lt;/article&gt;
 &lt;article&gt;  
@@ -103,10 +103,10 @@
 			<section aria-label="Sections">
 				<h2 id="sections">Sections</h2>
 				<p>The HTML5 <code>&lt;section&gt;</code> element marks a general region of a web page or an article. It is used for thematic grouping of content.</p>
-				<h3 id="">Code Snippet</h3>
+			
 				 <span class="wb-prettify"></span>
 <pre>
- <code class=‚Äùlanguage-html‚Äù>&lt;section&gt;
+ <code class="ùlanguage-html"ù>&lt;section&gt;
 	&lt;h2&gt;Chapter 2&lt;/h2&gt;
 &lt;/section&gt;</code>
 </pre>
@@ -118,34 +118,34 @@
 			<section aria-label="Quotes">
 				<h2 id="quotes">Quotes</h2>
 				<p>Identifying a quotation helps clarify that the content is attributed to another author. Quotes can be marked up as inline or as blocks of text. Assistive technologies can convey to users where a quote starts and ends, which can avoid misunderstandings.</p>
-				<h3>Example 1: Blockquote</h3>
+				<h3 class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example 1: Blockquote</h3>
 				<p>Use the <code>&lt;blockquote&gt;</code> element for longer and more complex quotes. It can contain paragraphs, headings, and other text structure elements. Those should reflect the structure of the cited document. The <code>&lt;cite&gt;</code> element is used to refer to the source of the quote.</p>
 				<h4 id="">Example</h4>
-				<p>The following is a definition on Page Structure Concept from W3 WAI.</p>
-				<p>Well-structured content allows more efficient navigation and processing. Use HTML and WAI-ARIA to improve navigation and orientation on web pages and in applications.</p>
-				<h4 id="">Code Snippet</h4>
+				<p>The following is a definition on <cite>Page Structure Concept</cite> from W3 WAI.</p>
+				<blockquote>
+					<p>Well-structured content allows more efficient navigation and processing. Use HTML and WAI-ARIA to improve navigation and orientation on web pages and in applications.</p>
+				</blockquote>	
 <pre>
- <code class=‚Äùlanguage-html‚Äù>&lt;p&gt;The following is a definition on&lt;cite&gt;Page Structure Concept&lt;/cite&gt; from W3 WAI.&lt;/p&gt;
+ <code class="ùlanguage-html"ù>&lt;p&gt;The following is a definition on &lt;cite&gt;Page Structure Concept&lt;/cite&gt; from W3 WAI.&lt;/p&gt;
 &lt;blockquote&gt;
 	&lt;p&gt;Well-structured content allows more efficient navigation and processing. Use HTML and WAI-ARIA to improve navigation and orientation on web pages and in applications. &lt;/p&gt;
 &lt;/blockquote&gt;</code>
 </pre>
-				<h3 id="">Example 2: Inline quote</h3>
+				<h3 id="" class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example 2: Inline quote</h3>
 				<p>For shorter quotes, that are usually embedded in another sentence, use the <code>&lt;q&gt;</code> element.</p>
 				<h4 id="">Example</h4>
-				<p>Helen Keller said, ‚ÄúSelf-pity is our worst enemy and if we yield to it, we can never do anything good in the world.‚Äù</p>
-				<h4 id="">Code Snippet</h4>
+				<p>Helen Keller said, <q>‚ÄúSelf-pity is our worst enemy and if we yield to it, we can never do anything good in the world.‚Äù</q></p>
+				
 <pre>
- <code class=‚Äùlanguage-html‚Äù>&lt;p&gt;Helen Keller said, &lt;q&gt;Self-pity is our worst enemy and if we yield to it, we can never do anything good in the world. &lt;/q&gt;&lt;/p&gt;</code></pre>
+ <code class="ùlanguage-html"ù>&lt;p&gt;Helen Keller said, &lt;q&gt;Self-pity is our worst enemy and if we yield to it, we can never do anything good in the world. &lt;/q&gt;&lt;/p&gt;</code></pre>
 
 			</section>
 			<section aria-label="Figures">
 				<h2 id="figures">Figures</h2>
 				<p>Figures are blocks with additional information set off from the main content of the page - sometimes referenced from the main text. They typically contain diagrams, illustrations, photos, code examples, tables, but can also include other content. For example, an annual report could reference a diagram containing the sales volumes of a product.</p>
 				<p>Each figure is wrapped in a <code>&lt;figure&gt;</code> element and labeled using a nested <code>&lt;figcaption&gt;</code> element.</p>
-				<h4 id="">Code Snippet</h4>
 <pre>
- <code class=‚Äùlanguage-html‚Äù>&lt;p&gt;
+ <code class="ùlanguage-html"ù>&lt;p&gt;
 The sales volume of our PearlyTooth product was steady the first three quarters but had a huge success in quarter four with the introduction of SuperBear in time for the holiday season. See graphic G3 for details.
  &lt;/p&gt;
  &lt;figure&gt;

--- a/learning/esdc-self-paced-web-accessibility-course/headings.html
+++ b/learning/esdc-self-paced-web-accessibility-course/headings.html
@@ -19,6 +19,8 @@
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css">
+	<script src="../../scripts/highlight.min.js"></script>
+	<script>hljs.highlightAll();</script>		
 </head>
 
 <body vocab="https://schema.org/" typeof="WebPage">
@@ -72,14 +74,18 @@
 				<li>Provide one h1 heading that describes the page content</li>
 			</ul>
 			<section aria-label="Good example: Heading hierarchy">
-				<h2 id="heading-hierarchy">Good example: Heading hierarchy</h2>
+				<h2 id="heading-hierarchy" class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example: Heading hierarchy</h2>
 				<p>Example of descriptive headings following a hierarchy without skipping a level:</p>
-				<p><code>&lt;h1&gt;Web Accessibility Fundamentals&lt;/h1&gt;</code></p>
-				<p><code>&lt;h2&gt;What is Web Accessibility? &lt;/h2&gt;</code></p>
-				<p><code>&lt;h2&gt;Types of Disabilities &lt;/h2&gt;</code></p>
-				<p><code>&lt;h3&gt;Blind&lt;/h3&gt;</code></p>
-				<p><code>&lt;h2&gt;Accessibility Guidelines &lt;h2&gt;</code></p>
-				<p><code>&lt;h3&gt;Web Content Accessibility Guidelines &lt;/h3&gt;</code></p>
+				<pre>
+					<code class="language-html">
+&lt;h1&gt;Web Accessibility Fundamentals&lt;/h1&gt;
+	&lt;h2&gt;What is Web Accessibility? &lt;/h2&gt;
+	&lt;h2&gt;Types of Disabilities &lt;/h2&gt;
+		&lt;h3&gt;Blind&lt;/h3&gt;
+	&lt;h2&gt;Accessibility Guidelines &lt;h2&gt;
+		&lt;h3&gt;Web Content Accessibility Guidelines &lt;/h3&gt;</code>
+				</pre>
+				
 			</section>
 			<section aria-label="Related WCAG resources">
 				<h2 id="resources-2">Related WCAG resources</h2>

--- a/learning/esdc-self-paced-web-accessibility-course/landmarks.html
+++ b/learning/esdc-self-paced-web-accessibility-course/landmarks.html
@@ -19,6 +19,8 @@
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css">
+	<script src="../../scripts/highlight.min.js"></script>
+	<script>hljs.highlightAll();</script>
 </head>
 
 <body vocab="https://schema.org/" typeof="WebPage">
@@ -210,10 +212,22 @@
 					<li>Use <code>role="search"</code> rather than <code>role="form"</code> when the form is used for search functionality.</li>
 				</ul>
 			</section>
-			<section aria-label="Example: Common landmarks">
-				<h2 id="example-1">Example: Common landmarks</h2>
+			<section aria-label="Good example: Common landmarks">
+				<h2 id="example-1"class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example: Common landmarks</h2>
 				<p>In this example, HTML5 sectioning elements define the landmarks for the most part. The <code>ARIA role="search"</code> attribute is unique and descriptive, and the redundant <code>role="main"</code> supports the IE 11 browser.</p>
-				<p><code>&lt;header&gt;   &lt;nav aria-label="global"&gt;…&lt;/nav&gt;  &lt;form role="search"&gt;…&lt;/form&gt;&lt;/header&gt;&lt;nav aria-label="main"&gt;…&lt;/nav&gt;&lt;main role="main"&gt;…&lt;/main&gt;&lt;aside&gt;…&lt;/aside&gt;&lt;footer aria-label="footer"&gt;…&lt;/footer&gt;</code></p>
+				<p class="wb-inv">Code begins</p>
+				<pre>
+					<code class="language-html">
+&lt;header&gt;
+   &lt;nav aria-label="global"&gt;…&lt;/nav&gt;
+   &lt;form role="search"&gt;…&lt;/form&gt;
+&lt;/header&gt;
+&lt;nav aria-label="main"&gt;…&lt;/nav&gt;
+&lt;main role="main"&gt;…&lt;/main&gt;
+&lt;aside&gt;…&lt;/aside&gt;
+&lt;footer aria-label="footer"&gt;…&lt;/footer&gt;</code>
+				</pre>
+				<p class="wb-inv">Code ends</p>
 				<img src="images/image1.png" class="img-responsive" alt=" Screenshot of landmark roles in their conventional locations. A header region holds nav and role=&#34;search&#34; landmarks. Below the header, left to right, are nav, main and aside landmarks. At the bottom is the footer landmark.">
 			</section>
 			<section aria-label="Related WCAG resources">

--- a/learning/esdc-self-paced-web-accessibility-course/language.html
+++ b/learning/esdc-self-paced-web-accessibility-course/language.html
@@ -73,7 +73,6 @@
         <div class="panel-body">
           <ul>
             <li><a href="#language">Language of page</a></li>
-			  <li><a href="#resources-5">Related WCAG resources</a></li>
 			  <li><a href="#language-of-parts">Language of parts</a></li>
 
           </ul>
@@ -96,10 +95,8 @@
 				</ul>
 				<p>Use a three-letter code if no other code is available. <a href="http://www.loc.gov/standards/iso639-2/php/code_list.php" target="_blank">ISO 639-2 three-letter code</a>.</p>
 				
-		  </section>
-			<section aria-label="Related WCAG resources">
-				<h2 id="resources-5">Related WCAG resources</h2>
-				<h3>Success criteria</h3>
+				<h3>Related WCAG resources</h3>
+				<h4>Success criteria</h4>
 				<ul>
 					<li>
 						<a href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page" target="_blank">3.1.1: Language of Page</a>
@@ -110,8 +107,9 @@
 					<li>
 						<a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H57" target="_blank">H57: Using the language attribute on the HTML element</a>
 					</li>
-				</ul>
-			</section>
+				</ul>				
+		  </section>
+
 			<section aria-label="Language of parts">
 				<h2 id="language-of-parts">Language of parts</h2>
 				<p>Any part of the page that is not written in the page’s primary language must specify its language. Set the lang attribute on the text’s parent element, with a value indicating the language of the part. </p>

--- a/learning/esdc-self-paced-web-accessibility-course/lists.html
+++ b/learning/esdc-self-paced-web-accessibility-course/lists.html
@@ -105,7 +105,7 @@
 					<li>Onions</li>
 					<li>Garlic</li>
 				</ul>
-				<p>Code Snippet:</p>
+			
 				 <span class="wb-prettify"></span>
 <pre>
  <code class=”language-html”>&lt;ul&gt;
@@ -130,7 +130,7 @@ Use ordered lists (<code>&lt;ol&gt;</code>) for sequential information, when the
 					<li>Deglaze using the tomatoes.</li>
 					<li>Add corn and beans.</li>
 				</ol>
-				<p>Code Snippet:</p>
+			
 <pre>
  <code class=”language-html”>&lt;ol&gt;
 	&lt;li&gt;Cook beans for 45 minutes.&lt;/li&gt;
@@ -156,7 +156,7 @@ Use ordered lists (<code>&lt;ol&gt;</code>) for sequential information, when the
 	<li>Deglaze using the tomatoes.</li>
 	<li>Add corn and beans.</li>
 				</ol>
-				<p>Code Snippet:</p>
+				
 <pre>
  <code class=”language-html”>&lt;ol&gt;
 	&lt;li&gt;Prepare ingredients
@@ -175,7 +175,7 @@ Use ordered lists (<code>&lt;ol&gt;</code>) for sequential information, when the
 				<h2 id="description-list">Description list</h2>
 				<p>A description list consists of one or more term and description groupings. Each grouping associates one or more terms (the contents of <code>&lt;dt&gt;</code> elements) with one or more descriptions (the contents of <code>&lt;dd&gt;</code> elements).</p>
 				<p>A grouping begins either on the first item of the list or whenever a <code>&lt;dt&gt;</code> element follows an <code>&lt;dd&gt;</code> element.</p>
-				<h3>Example 1: One term, multiple descriptions</h3>
+				<h3 class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example 1: One term, multiple descriptions</h3>
 				<p>In the following example, John and Luke are described as authors, and Frank is described as editor.</p>
 				<p>EXAMPLE:</p>
 				<dl>  
@@ -184,7 +184,7 @@ Use ordered lists (<code>&lt;ol&gt;</code>) for sequential information, when the
 				<dd>Luke</dd>
 				  <dt>Editor</dt>  
 				<dd>Frank</dd></dl>
-				<p>Code Snippet:</p>
+				
 <pre>
  <code class=”language-html”>&lt;dl&gt;  
 	&lt;dt&gt;Authors&lt;/dt&gt;
@@ -194,7 +194,7 @@ Use ordered lists (<code>&lt;ol&gt;</code>) for sequential information, when the
 	&lt;dd&gt;Frank&lt;/dd&gt;
 &lt;/dl&gt;</code>
 </pre>
-				<h3>Example 2: Multiple terms, one description</h3>
+				<h3 class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example 2: Multiple terms, one description</h3>
 				<p>In the next example, two different spellings of a word are defined using description lists. In such cases, use the dfn element to mark up the defined term.</p>
 				<p>EXAMPLE:</p>
 				<dl>   
@@ -202,15 +202,15 @@ Use ordered lists (<code>&lt;ol&gt;</code>) for sequential information, when the
 <dt lang="en-GB"><dfn>colour</dfn></dt>
 <dd>A sensation which (in humans) derives from the ability of the fine structure of the eye to distinguish three differently filtered analyses of a view.</dd>
 </dl>
-	<p>Code Snippet:</p>
+	
 <pre>
  <code class=”language-html”>&lt;dl&gt;   
-&lt;dt lang="en-US"&gt;&lt;dfn&gt;color&lt;/dfn&gt;&lt;/dt&gt;
-&lt;dt lang="en-GB"&gt;&lt;dfn&gt;colour&lt;/dfn&gt;&lt;/dt&gt;
-&lt;dd&gt;A sensation which (in humans) derives from the ability of the fine structure of the eye to distinguish three differently filtered analyses of a view.&lt;/dd&gt;
+	&lt;dt lang="en-US"&gt;&lt;dfn&gt;color&lt;/dfn&gt;&lt;/dt&gt;
+	&lt;dt lang="en-GB"&gt;&lt;dfn&gt;colour&lt;/dfn&gt;&lt;/dt&gt;
+	&lt;dd&gt;A sensation which (in humans) derives from the ability of the fine structure of the eye to distinguish three differently filtered analyses of a view.&lt;/dd&gt;
 &lt;/dl&gt;</code>
 </pre>
-				<h3>Example 3: Multiple terms, multiple descriptions</h3>
+				<h3 class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example 3: Multiple terms, multiple descriptions</h3>
 				<p>In this example, John and Luke are authors and also editors:</p>
 				<p>EXAMPLE:</p>
 				<dl>
@@ -219,7 +219,7 @@ Use ordered lists (<code>&lt;ol&gt;</code>) for sequential information, when the
 	<dd>John</dd>  
 	<dd>Luke</dd>
 </dl>
-				<p>Code Snippet:</p>
+				
 <pre>
  <code class=”language-html”>&lt;dl&gt;
 	&lt;dt&gt;Authors&lt;/dt&gt; 

--- a/learning/esdc-self-paced-web-accessibility-course/parsing-and-validity.html
+++ b/learning/esdc-self-paced-web-accessibility-course/parsing-and-validity.html
@@ -108,7 +108,7 @@
 				<h2 id="elements-specifications">Elements are nested according to their specifications</h2>
 				<p>Elements with a parent-child relationship are cleanly nested, with the start and end tags of the child element fully inside the start and end tags of the parent element. </p>
 
-				<h3>Good example: the start and end list item tags are fully inside the parent list’s tags</h3>
+				<h3 class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example: the start and end list item tags are fully inside the parent list’s tags</h3>
 <pre>
  <code class=”language-html”>&lt;ul&gt;
 	&lt;li&gt;Corn&lt;/li&gt;
@@ -116,10 +116,10 @@
 	&lt;li&gt;Beans&lt;/li&gt;
 &lt;/ul&gt;</code>
 </pre>
-				<h3 id="idelem4x9895">Good example: an inline strong element’s tags are fully nested inside the parent paragraph’s tags</h3>
+				<h3 id="idelem4x9895" class="text-success"><span class="glyphicon glyphicon-ok-circle"></span> Good example: an inline strong element’s tags are fully nested inside the parent paragraph’s tags</h3>
 				<pre>
  <code class=”language-html”>&lt;p&gt;&lt;strong&gt;Important:&lt;/strong&gt; Lock the door when you leave.&lt;/p&gt;</code></pre>
-				<h3>Bad example: broken list</h3>
+				<h3 class="text-danger"><span class="glyphicon glyphicon-remove-circle"></span> Bad example: broken list</h3>
 
 				<p>Both “list item with no parent list element” and “Text with no parent list item element” are caught by the W3C Validator.</p>
 <pre>


### PR DESCRIPTION
**landmarks.html**
- Added "Good" to example title and WET class
- Added codeblock markup
- Added highlight.js  in the head

**headings.html**
- Added "Good" to example title and WET class
- Added codeblock markup
- Added highlight.js  in the head

**content-structure.html**
- Replaced class=â€language-htmlâ€ with class="language-html" on code blocks
- Removed the inconsistently-applied heading "Code Snippet" (Mohammed is adding visually-hidden messages)
- Added "Good" example and class
- Added quote markup to two examples

**language.html**
- Demoted the heading "Related WCG resources", removed it's parent <section>, moved it into the previous section, removed from TOC

**parsing-and-validity.html**
- Added "Good" and "Bad" example WET classes