### PR TITLE
path to syntax highlighter CSS

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/module2/language.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/language.html
@@ -19,7 +19,7 @@
 	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
-	<link rel="stylesheet" href="../../css/a11y-dark.css">
+	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>
 	<script>hljs.highlightAll();</script>
 	
@@ -79,8 +79,8 @@
         </div>
       </div>
    </nav>
-			<section aria-label="Language of Page">
-				<h2 id="language">Language of Page</h2>
+			<section aria-label="Language of page">
+				<h2 id="language">Language of page</h2>
 				<p>The <code>&lt;html&gt;</code> element must have a <code>lang</code> attribute value that identifies the primary language of the page. 
           Without it, the page content may be rendered as gibberish by some screen readers. </p>
 


### PR DESCRIPTION
In language.html, fixed the path to the CSS and set a heading in sentence case.