### PR TITLE
Shortened long heading

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/module2/landmarks.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/landmarks.html
@@ -70,12 +70,9 @@
         <div class="panel-body">
           <ul>
             <li><a href="#landmarks">Designing with landmarks</a></li>
-			 <li><a href="#regions-landmarks">Follow these best practices for page regions and landmarks</a></li>
+			 <li><a href="#regions-landmarks">Best practices for page regions and landmarks</a></li>
               <li><a href="#example-1">Good example: Common landmarks</a></li>
               <li><a href="#resources-1">Related WCAG resources</a></li>
-              <li><a href="#heading-hierarchy">Good example: Heading hierarchy</a></li>
-			  <li><a href="#resources-2">Related WCAG resources</a></li>
-
           </ul>
         </div>
       </div>
@@ -193,8 +190,8 @@
 			    </tbody>
 				</table>
 			</section>
-			<section aria-label="Follow these best practices for page regions and landmarks:">
-<h2 id="regions-landmarks">Follow these best practices for page regions and landmarks</h2>
+			<section aria-label="Best practices for page regions and landmarks:">
+<h2 id="regions-landmarks">Best practices for page regions and landmarks</h2>
 				<ul>
 					<li>Use HTML5 sectioning elements (preferred) to identify regions on a page. Use ARIA landmark role attributes if HTML5 sectioning elements cannot be used.
 						<ul>


### PR DESCRIPTION
From "Follow these best practices for page regions and landmarks"
To "Best practices for page regions and landmarks"