### PR TITLE
Team page update en-fr

### DIFF
--- a/teams/svatic-ictaas/index-en.html
+++ b/teams/svatic-ictaas/index-en.html
@@ -1,596 +1,1563 @@
 <!DOCTYPE html>
-<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
-<!--[if gt IE 8]><!-->
-<html class="no-js" lang="en" dir="ltr">
-<!--<![endif]-->
-
-<head>
-	<meta charset="utf-8">
-	<!-- Web Experience Toolkit (WET) / Boîte à outils de l'exp&eacute;rience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-	<title>IT Accessibility Office (ITAO) Team - ESDC / IT Accessibility office</title>
-	<meta content="width=device-width,initial-scale=1" name="viewport">
-	<!-- Meta data -->
-	<meta name="description"
-		content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
-	<!-- Meta data-->
-	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
-	<!-- Write closure template -->
-	<script src="../../scripts/refTop.min.js"></script>
-	<link rel="stylesheet" href="../../css/style.css">
-	<link rel="stylesheet" href="../styles/custom.css">
-</head>
-
-<body vocab="https://schema.org/" typeof="WebPage">
-	<div id="def-top">
-	</div>
-	<script>
-		var defTop = document.getElementById("def-top");
-		defTop.outerHTML = wet.builder.appTop({
-			"appName": [{
-				"text": "ESDC / IT Accessibility office",
-				"href": "../../index.html"
-
-			}],
-			"breadcrumbs": [{
-				"title": "Home",
-				"href": "../../index.html"
-
-			}],
-			"lngLinks": [{
-				"lang": "fr",
-				"href": "./index-fr.html",
-				"text": "Français"
-			}],
-			"menuPath": "../../ajax/menu-en.html"
-		});
-	</script>
-	<main role="main" property="mainContentOfPage" class="container">
-		<h1 property="name" id="wb-cont">IT Accessibility Office (<abbr title="IT Accessibility Office">ITAO</abbr>)
-			Team</h1>
-
-		<div class="row wb-eqht wb-init wb-eqht-inited mrgn-tp-lg">
-
-			<section class="col-xs-12">
-				<h2 class="text-center mrgn-bttm-lg">Management Team</h2>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Andre Demers</span>
-							<span class="long-title">Acting Director - IT Accessibility Office</span>
-							<br>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:andre.demers@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-								<li><a href="https://www.linkedin.com/in/andre-demers-6a196820/"><i
-											class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
-												class="wb-inv">LinkedIn</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Asha Natraj</span>
-							<span class="long-title">IM/IT Manager - Accessibility Compliance Project / Awareness</span>
-						</div>
-						<div class="info"></div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:asha.natraj@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/roch.jpg" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Roch Lambert</span>
-							<span class="long-title">IM/IT Manager - ICT Accessibility Audit and Strategy</span>
-							<br>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Certified Professional in Web Accessibility (CPWA - IAAP)</li>
-								<li><a href="https://centreforinclusivedesign.org.au/index.php/pcwa/">UNSW Professional
-										Certificate in Web Accessibility</a></li>
-								<li>Certified Professional in Accessibility Core Competencies (CPACC)</li>
-								<li>Web Accessibility Specialist (WAS)</li>
-								<li>Accessible Document Specialist (ADS)</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:roch.lambert@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-								<li><a href="https://twitter.com/rlambert27"><i
-											class="fab fa-twitter fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Twitter</span></i></a></li>
-								<li><a href="https://www.linkedin.com/in/rlambert27/"><i
-											class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
-												class="wb-inv">LinkedIn</span></i></a></li>
-								<li><a href="https://github.com/rlambert27"><i
-											class="fab fa-github fa-lg mrgn-rght-sm"><span
-												class="wb-inv">GitHub</span></i></a></li>
-								<li><a href="https://www.accessibilityassociation.org/professionaldirectory"><i
-											class="fa fa-certificate fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Certificate</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Titus Cristea</span>
-							<span class="long-title">IM/IT Manager - Accessibility Centre of Excellence</span>
-						</div>
-						<div class="info"></div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:titus.cristea@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-								<li><a href="https://www.linkedin.com/in/titus-cristea-mpa-pmp-32a68b4/"><i
-											class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
-												class="wb-inv">LinkedIn</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				
-			</section>
-
-
-			<section class="col-xs-12 brdr-tp mrgn-tp-lg">
-				<h2 class="text-center mrgn-bttm-lg">Full Team</h2>
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/andre-lorena.jpg" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Andrea Pachon</span>
-							<span class="title">Administrative Assistant</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:andrea.l.pachon@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-				<div class="col-xs-12 col-sm-6 col-md-4 ">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Alexis van den Hoogen</span>
-							<span class="title">Acting Team Lead</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>International Software Testing Qualifications Board (ISTQB) Foundation Level
-									Certified</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:alexis.vandenhogen@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Andrew Nordlund</span>
-							<span class="title">Accessibility Technical Advisor</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>B.Sc. in Computer Science (Laurentian University)</li>
-								<li>Certified Web Accessibility Specialist (WAS - IAAP)</li>
-								<li>Certified NVDA Expert</li>
-								<li>Web Programmer</li>
-								<li>Developer of Browser Extensions</li>
-							</ul>
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:andrew.nordlund@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-								<li><i class="fab fa-linkedin fa-lg mrgn-rght-sm"></i><a
-										href="https://www.linkedin.com/in/andrew-nordlund-52607734"><span
-											class="wb-inv">LinkedIn</span></a></li>
-								<li><a href="https://github.com/andrewnordlund/"><i
-											class="fab fa-github fa-lg mrgn-rght-sm"><span
-												class="wb-inv">GitHub</span></i></a></li>
-								<li><a href="https://www.accessibilityassociation.org/s/wascertificants#Certificants3"><i
-											class="fa fa-certificate fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Certificate</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/anne.jpg" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Anne Simard</span>
-							<span class="title">Accessibility Technical Advisor</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Assistive Technology Applications Certificate Program (ATACP) - California State
-									University Northridge (CSUN)/2018</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><i class="fab fa-linkedin fa-lg mrgn-rght-sm"></i><a
-										href="https://www.linkedin.com/in/anne-simard-6b117a45"><span
-											class="wb-inv">LinkedIn</span></a></li>
-								<li><a href="mailto:anne.simard@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-								<li><a href="https://mobile.twitter.com/dragonlady0405"><i
-											class="fab fa-twitter fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Twitter</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Byatris Kattackal</span>
-							<span class="title">Accessibility Technical Advisor</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Certified Professional in Accessibility Core Competencies (CPACC)</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:byatris.kattackal@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Delphine Gilbert-Laurendeau</span>
-							<span class="title">Analyst, IT Business Line Support Services</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Certified Professional in Accessibility Core Competencies (<abbr
-										title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)
-								</li>
-								<li>Accessible Document Specialist (<abbr
-										title="Accessible Document Specialist">ADS</abbr>)</li>
-								<li>Web programmer and designer</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="https://www.linkedin.com/in/dgilbertlaurendeau/"><i
-											class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
-												class="wb-inv">LinkedIn</span></i></a></li>
-								<li><a href="mailto:delphine.gilbertlaurendeau@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Fr&eacute;dy D&eacute;monl&eacute; Moko</span>
-							<span class="title">Acting Accessibility Technical Advisor</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>MSc student in Information Technology Management</li>
-								<li>Bachelor of Applied Science (B.A.Sc.), Computer Science</li>
-								<li>Web accessibility</li>
-								<li>Web analytics</li>
-								<li>Programming</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:fredy.demonlemoko@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-								<li><a href="https://github.com/fredymoko"><i
-											class="fab fa-github fa-lg mrgn-rght-sm"><span
-												class="wb-inv">GitHub</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Jolanta Szulc</span>
-							<span class="title">Analyst, IT Business Line Support Services</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Bachelor of Science in Computer Science</li>
-								<li>Certified Professional in Accessibility Core Competencies (CPACC - IAAP)</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:jolanta.szulc@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Kelly-Ann Lauzon</span>
-							<span class="title">Business Analyst</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:kellyanne.lauzon@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Miles King</span>
-							<span class="title">Analyst, IT Business Line Support Services</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:miles.h.king@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Nicolas Raymond</span>
-							<span class="title">Team Lead</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Web accessibility</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:nicolas.raymond@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Pierre Larochelle</span>
-							<span class="title">Analyst, IT Business Line Support Services</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:pierre.r.larochelle@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Sylvie Patry</span>
-							<span class="title">Analyst, IT Business Line Support Services</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:sylvie.patry@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">St&eacute;phane Mallette</span>
-							<span class="title">Analyst, IT Business Line Support Services</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:stephane.mallette@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Val&eacute;rie Auger</span>
-							<span class="title">IT Accessibility Coordinator</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:valerie.auger@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Wenjun Tang</span>
-							<span class="title">Analyst, IT Business Line Support Services</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:wenjun.tang@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Email</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-			</section>
-		</div>
-		<div id="def-preFooter"></div>
-		<script src="../../scripts/preFooter.min.js"></script>
-	</main>
-	<div id="def-footer"></div>
-	<script src="../../scripts/appFooter.min.js"></script>
-	<script src="../../scripts/refFooter.min.js"></script>
-	<script src="../../scripts/bati-itao.min.js"></script>
-</body>
-
-</html>
+<!--[if lt IE 9]>
+<html class="no-js lt-ie9" lang="en" dir="ltr">
+   <![endif]-->
+   <!--[if gt IE 8]><!-->
+   <html class="no-js" lang="en" dir="ltr">
+      <!--<![endif]-->
+      <head>
+         <meta charset="utf-8">
+         <!-- Web Experience Toolkit (WET) / Boîte à outils de l'exp&eacute;rience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+         <title>IT Accessibility Office (ITAO) Team - ESDC / IT Accessibility office</title>
+         <meta content="width=device-width,initial-scale=1" name="viewport">
+         <!-- Meta data -->
+         <meta name="description"
+            content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
+         <!-- Meta data-->
+         <!-- Load closure template scripts -->
+         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <!-- Write closure template -->
+         <script src="../../scripts/refTop.min.js"></script>
+         <link rel="stylesheet" href="../../css/style.css">
+         <link rel="stylesheet" href="../styles/custom.css">
+      </head>
+      <body vocab="https://schema.org/" typeof="WebPage">
+         <div id="def-top">
+         </div>
+         <script>
+            var defTop = document.getElementById("def-top");
+            defTop.outerHTML = wet.builder.appTop({
+            	"appName": [{
+            		"text": "ESDC / IT Accessibility office",
+            		"href": "../../index.html"
+            
+            	}],
+            	"breadcrumbs": [{
+            		"title": "Home",
+            		"href": "../../index.html"
+            
+            	}],
+            	"lngLinks": [{
+            		"lang": "fr",
+            		"href": "./index-fr.html",
+            		"text": "Français"
+            	}],
+            	"menuPath": "../../ajax/menu-en.html"
+            });
+         </script>
+         <main role="main" property="mainContentOfPage" class="container">
+            <h1 property="name" id="wb-cont">IT Accessibility Office (<abbr title="IT Accessibility Office">ITAO</abbr>)
+               Team
+            </h1>
+            <div class="row wb-eqht wb-init wb-eqht-inited mrgn-tp-lg">
+               <section class="col-xs-12">
+                  <h2 class="text-center mrgn-bttm-lg">Management Team</h2>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Andre Demers</span>
+                           <span class="long-title">Acting Director - IT Accessibility Office</span>
+                           <br>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:andre.demers@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                              <li><a href="https://www.linkedin.com/in/andre-demers-6a196820/"><i
+                                 class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">LinkedIn</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Asha Natraj</span>
+                           <span class="long-title">IM/IT Manager - Accessibility Compliance Project / Awareness</span>
+                        </div>
+                        <div class="info"></div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:asha.natraj@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/roch.jpg" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Roch Lambert</span>
+                           <span class="long-title">IT Manager, IT Business Line 
+                           Advisory Services</span>
+                           <br>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Web Accessibility (CPWA - IAAP)</li>
+                              <li><a href="https://centreforinclusivedesign.org.au/index.php/pcwa/">UNSW Professional
+                                 Certificate in Web Accessibility</a>
+                              </li>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                              <li>Web Accessibility Specialist (<abbr
+                                 title="Web Accessibility Specialist">WAS</abbr>)</li>
+                              <li>Accessible Document Specialist (<abbr
+                                 title="Accessible Document Specialist">ADS</abbr>)</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:roch.lambert@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                              <li><a href="https://twitter.com/rlambert27"><i
+                                 class="fab fa-twitter fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Twitter</span></i></a></li>
+                              <li><a href="https://www.linkedin.com/in/rlambert27/"><i
+                                 class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">LinkedIn</span></i></a></li>
+                              <li><a href="https://github.com/rlambert27"><i
+                                 class="fab fa-github fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">GitHub</span></i></a></li>
+                              <li><a href="https://www.accessibilityassociation.org/professionaldirectory"><i
+                                 class="fa fa-certificate fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Certificate</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Titus Cristea</span>
+                           <span class="long-title">IT Manager, IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                              <li>PMP - Project Management Professional</li>
+                              <li>PR2P - Prince2 Foundation and Practitioner Certified</li>
+                              <li>ITIL Foundation Certified</li>
+                              <li>MPA - Master of Public Administration (Management) - University of Quebec (ENAP)</li>
+                              <li>B.Eng - Bachelor of engineering in Computer engineering</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:titus.cristea@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                              <li><a href="https://www.linkedin.com/in/titus-cristea-mpa-pmp-32a68b4/"><i
+                                 class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">LinkedIn</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/andre-lorena.jpg" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Andrea Pachon</span>
+                           <span class="title">Administrative Assistant</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:andrea.l.pachon@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+               </section>
+               <section class="col-xs-12 brdr-tp mrgn-tp-lg">
+                  <h2 class="text-center mrgn-bttm-lg">ICTAAS Team</h2>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Alexis van den Hoogen</span>
+                           <span class="title">Acting Team Lead</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>International Software Testing Qualifications Board (<abbr
+                                 title="International Software Testing Qualifications Board">ISTQB</abbr>)  Foundation Level
+                                 Certified
+                              </li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:alexis.vandenhogen@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/anne.jpg" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Anne Simard</span>
+                           <span class="title">Accessibility Technical Advisor</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Assistive Technology Applications Certificate Program (<abbr
+                                 title="Assistive Technology Applications Certificate Program">ATACP</abbr>)- California State
+                                 University Northridge (<abbr
+                                 title="California State University Northridge">CSUN</abbr>) /2018
+                              </li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:anne.simard@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Andrew Nordlund</span>
+                           <span class="long-title">IT Technical Advisor, IT Business Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:andrew.nordlund@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Ala Hamada</span>
+                           <span class="title">Analyst, IT Business Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Web accessibility</li>
+                              <li>Document accessibility</li>
+                              <li>I do have some experience in software accessibility as well.</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:ala.hamada@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                              <li><a href="https://www.linkedin.com/in/alahamada/"><i
+                                 class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">LinkedIn</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Brendan Carroll</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:brendan.carroll@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Byatris Kattackal</span>
+                           <span class="long-title">IT Technical Advisor, IT 
+                           Business Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:byatris.kattackal@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Balakanthan Ratnam</span>
+                           <span class="long-title">Analyst, IT Business Line Advisory Services
+                           </span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:balakanthan.ratnam@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Charlie Iro-Young</span>
+                           <span class="long-title">Support Technician</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:charlie.iroyoung@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Delphine Gilbert-Laurendeau</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)
+                              </li>
+                              <li>Accessible Document Specialist (<abbr
+                                 title="Accessible Document Specialist">ADS</abbr>)</li>
+                              <li>Web Accessibility Specialist (<abbr
+                                 title="Web Accessibility Specialist">WAS</abbr>)</li>
+                              <li>Document and web accessibility</li>
+                              <li>Web programming and Web design</li>
+                              <li>Graphic design</li>
+                              <li>SharePoint expert</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="https://www.linkedin.com/in/dgilbertlaurendeau/"><i
+                                 class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">LinkedIn</span></i></a></li>
+                              <li><a href="mailto:delphine.gilbertlaurendeau@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Dominic MacMillan</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:dominic.macmillan@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Frank Basham</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:frank.basham@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Fr&eacute;dy D&eacute;monl&eacute; Moko</span>
+                           <span class="long-title">IT Technical Advisor, IT 
+                           Business Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>MSc student in Information Technology Management</li>
+                              <li>Bachelor of Applied Science (B.A.Sc.), Computer Science</li>
+                              <li>Web accessibility</li>
+                              <li>Web analytics</li>
+                              <li>Programming</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:fredy.demonlemoko@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                              <li><a href="https://github.com/fredymoko"><i
+                                 class="fab fa-github fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">GitHub</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Jean-Michel Dorais</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:jeanmichel.dorais@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Courriel</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Jolanta Szulc</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Bachelor of Science in Computer Science</li>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>) - Internationnal Association of Accessibility Professionals (<abbr
+                                 title="Internationnal Association of Accessibility Professionals">IAAP</abbr>) </li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:jolanta.szulc@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Kellyanne Lecuyer</span>
+                           <span class="long-title">Support Technician</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Web programmer and designer</li>
+                              <li>Web accessibility</li>
+                              <li>Graphic Design</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:kellyanne.lecuyer@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                              <li><a href="https://github.com/kellyanne-lecuyer/"><i
+                                 class="fab fa-github fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">GitHub</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Larry Bowden</span>
+                           <span class="title">Analyst, IT Business Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>International Software Testing Qualifications Board (<abbr
+                                 title="International Software Testing Qualifications Board">ISTQB</abbr>)  Certified</li>
+                              <li>Document Accessibility</li>
+                              <li>Accessible Audio and Video</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:larry.bowden@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Maxim Martel</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:maxim.martel@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Maxim Perry</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Web Accessibility Specialist (<abbr
+                                 title="Web Accessibility Specialist">WAS</abbr>)</li>
+                              <li>Web Accessibility </li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:maxim.perry@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                              <li><a href="https://twitter.com/PerryMaxim"><i
+                                 class="fab fa-twitter fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Twitter</span></i></a></li>
+                              <li><a href="https://www.linkedin.com/in/maxim-perry/"><i
+                                 class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">LinkedIn</span></i></a></li>
+                              <li><a href="https://github.com/MaximPerry"><i
+                                 class="fab fa-github fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">GitHub</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Miles King</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:miles.h.king@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Nicholas Atkins</span>
+                           <span class="long-title">IT Analyst, IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:nicholas.atkins@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Nicolas Raymond</span>
+                           <span class="long-title">IT Team Leader, IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                              <li>Web accessibility</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:nicolas.raymond@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Olga Maximova</span>
+                           <span class="title">Analyst, IT Business
+                           Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Web Accessibility Specialist (<abbr
+                                 title="Web Accessibility Specialist">WAS</abbr>)</li>
+                              <li>Web accessibility</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:olga.maximova@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Sean Toogood</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:sean.toogood@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">St&eacute;phane Mallette</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:stephane.mallette@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Sylvie Patry</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Web accessibility</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:sylvie.patry@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Omar Touma</span>
+                           <span class="title">Sr Advisor, Infrastructure/Ops</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                              <li>Web programmer</li>
+                              <li>Web designer</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:omar.touma@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Val&eacute;rie Auger</span>
+                           <span class="title">Business analyst</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Document audit</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:valerie.auger@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Wenjun Tang</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:wenjun.tang@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+               </section>
+               <section class="col-xs-12 brdr-tp mrgn-tp-lg">
+                  <h2 class="text-center mrgn-bttm-lg">ACP Awareness</h2>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Abhishek Bothra</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:abhishek.bothra@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Courriel</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Annie Tremblay</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:annie.tremblay@servicecanada.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Courriel</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Cathy Teixeira</span>
+                           <span class="title">Acting Team Leader, Analyst</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Promotion of accessibility through articles and awareness sessions</li>
+                          </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:cathy.teixeira@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Christine  Poirier</span>
+                           <span class="title">Officer, Project services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:christine.poirier@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Claude Bertrand</span>
+                           <span class="title">Consultant / Project Manager</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:claude.bertrand@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Jeffery Orchard</span>
+                           <span class="title">Consultant /Accessibility Coach</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Master's degree, MI</li>
+                              <li>Digital accessibility</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:jeffery.orchard@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">John Avudria</span>
+                           <span class="title">Consultant</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:john.avudria@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Joshua Malette</span>
+                           <span class="title">Support Technician</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:joshua.malette@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Kelly-Anne Lauzon</span>
+                           <span class="title">Officer, Project services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:kellyanne.lauzon@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Kevin Cain</span>
+                           <span class="long-title">IT Team Leader, IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:kevin.cain@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Michael Chan</span>
+                           <span class="title">Consultant /Accessibility 
+                           Coach</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Computer Engineering (B.A.Sc)</li>
+                              <li>Web Accessibility</li>
+                              <li>Document Accessibility</li>
+                              <li>Assistive Technologies</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:michael.chan@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                              <li><a href="http://www.linkedin.com/in/michaelychan1"><i
+                                 class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">LinkedIn</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Micheline Dib</span>
+                           <span class="title">Analyst, IT Business Line Support Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:micheline.dib@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Courriel</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Minaxi Patel</span>
+                           <span class="title">Consultant/ Loan to iService</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:minaxi.patel@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Mohammed Qadeer</span>
+                           <span class="title">Consultant / Accessibility Coach</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:mohammed.quadeer@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Pierre Larochelle</span>
+                           <span class="long-title">IT Team Leader / IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:pierre.r.larochelle@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Richa Sharma</span>
+                           <span class="title">Assistant / Project services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:richa.sharma@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Rudolfo Lamontagne</span>
+                           <span class="title">Assistant / Project services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:rudolfo.lamontagne@hrsdc-rhdcc.gc.ca"><i class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+               </section>
+               <section class="col-xs-12 brdr-tp mrgn-tp-lg">
+                  <h2 class="text-center mrgn-bttm-lg">ACE Team</h2>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Annie-Claude Chapleau</span>
+                           <span class="long-title">IT Analyst / IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:annieclaude.chapleau@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Chantal Basque</span>
+                           <span class="title">Analyst / IT Business 
+                           Line Advisory Services
+                           </span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:chantal.basque@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Hamza Lyazidi</span>
+                           <span class="title">IT Analyst / IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Assistive Hardware</li>
+                              <li>Computers Management</li>
+                              <li>Product Management</li>
+                              <li>PowerShell</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:hamza.lyazidi@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Jean-Pierre Larose</span>
+                           <span class="long-title">IT Team Leader / IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                              <li>AT support</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:jeanpierre.larose@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Joel Collin</span>
+                           <span class="long-title">IT Technical Advisor / IT 
+                           Business Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Low vision, Cognitive, Hard of Hearing expertise</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:joel.collin@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Liban Darar</span>
+                           <span class="title">Analyst / IT Business 
+                           Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Cisco Networking Administration</li>
+                              <li>Assistive Technology Specialist</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:liban.darar@hrsdc-rhdcc.gc.ca
+                                 "><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Luis Fernandez</span>
+                           <span class="title">Analyst / IT Business 
+                           Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                              <li>Zoomtext certified</li>
+                              <li>JAWS certified</li>
+                              <li>Support and troubleshooting</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:luisraciel.fernandez@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Marc-Andr&eacute; Ferron</span>
+                           <span class="title">Analyst / IT Business 
+                           Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Technology Product support and technical support for client who have mobility issues</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:marc.a.ferron@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Martin Villeneuve</span>
+                           <span class="title">Analyst / IT Business 
+                           Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:martin.m.villeneuve@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Michel Cormier</span>
+                           <span class="long-title">IT Team Leader / IT Business Line 
+                           Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Certified Professional in Accessibility Core Competencies (<abbr
+                                 title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                              <li>JAWS certified</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:michel.cormier@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">S&eacute;bastien St-Pierre-Dufour</span>
+                           <span class="title">Analyst / IT Business 
+                           Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Accessibility for cognitive and hard of hearing disabilities</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:sebastien.stpierredufour@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Sylvain B&eacute;langer</span>
+                           <span class="title">Analyst / IT Business 
+                           Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                           <ul>
+                              <li>Low vision expert</li>
+                           </ul>
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:sylvain.d.belanger@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 col-md-4 ">
+                     <div class="team-member">
+                        <div class="photo-container">
+                           <img src="../images/placeholder.png" alt="">
+                        </div>
+                        <div class="text">
+                           <span class="name">Viviane Aoud</span>
+                           <span class="title">IT Technical Advisor / IT 
+                           Business Line Advisory Services</span>
+                        </div>
+                        <div class="info">
+                        </div>
+                        <div class="social">
+                           <ul class="list-unstyled list-inline">
+                              <li><a href="mailto:viviane.aouad@hrsdc-rhdcc.gc.ca"><i
+                                 class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                                 class="wb-inv">Email</span></i></a></li>
+                           </ul>
+                        </div>
+                     </div>
+                  </div>
+               </section>
+            </div>
+            <div id="def-preFooter"></div>
+            <script src="../../scripts/preFooter.min.js"></script>
+         </main>
+         <div id="def-footer"></div>
+         <script src="../../scripts/appFooter.min.js"></script>
+         <script src="../../scripts/refFooter.min.js"></script>
+         <script src="../../scripts/bati-itao.min.js"></script>
+      </body>
+   </html>

--- a/teams/svatic-ictaas/index-fr.html
+++ b/teams/svatic-ictaas/index-fr.html
@@ -1,600 +1,1536 @@
 <!DOCTYPE html>
-<!--[if lt IE 9]><html class="no-js lt-ie9" lang="fr" dir="ltr"><![endif]-->
-<!--[if gt IE 8]><!-->
-<html class="no-js" lang="fr" dir="ltr">
-<!--<![endif]-->
-
-<head>
-	<meta charset="utf-8">
-	<!-- Web Experience Toolkit (WET) / Boîte à outils de l'exp&eacute;rience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-	<title>L'équipe du bureau de l’accessibilité de la TI - EDSC / Bureau de l’accessibilit&eacute; de la TI</title>
-	<meta content="width=device-width,initial-scale=1" name="viewport">
-	<!-- Meta data -->
-	<meta name="description"
-		content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieu du travail.">
-	<!-- Meta data-->
-
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
-
-	<script src="../../scripts/refTop.min.js"></script>
-	<link rel="stylesheet" href="../../css/style.css">
-	<link rel="stylesheet" href="../styles/custom.css">
-</head>
-
-<body vocab="https://schema.org/" typeof="WebPage">
-	<div id="def-top">
-	</div>
-
-	<script>
-		var defTop = document.getElementById("def-top");
-		defTop.outerHTML = wet.builder.appTop({
-			"appName": [{
-				"text": "EDSC / Bureau de l’accessibilit&eacute; de la TI",
-				"href": "../../index-fr.html"
-			}],
-			"breadcrumbs": [{
-				"title": "Accueil",
-				"href": "../../index-fr.html"
-			}],
-			"lngLinks": [{
-				"lang": "en",
-				"href": "./index-en.html",
-				"text": "English"
-			}],
-			"menuPath": "../../ajax/menu-fr.html"
-		});
-	</script>
-	<main role="main" property="mainContentOfPage" class="container">
-		<h1 property="name" id="wb-cont">L'&eacute;quipe de bureau l’accessibilit&eacute; de la TI (<abbr
-				title="L'&eacute;quipe de bureau l’accessibilit&eacute; de la TI ">ITAO</abbr>)</h1>
-
-		<div class="row wb-eqht wb-init wb-eqht-inited mrgn-tp-lg">
-
-			<section class="col-xs-12">
-				<h2 class="text-center mrgn-bttm-lg">Équipe de direction</h2>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Andre Demers</span>
-							<span class="title">Directeur intérimaire - Bureau d'accessibilité TI</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:andre.demers@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-								<li><a href="https://www.linkedin.com/in/andre-demers-6a196820/"><i
-											class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
-												class="wb-inv">LinkedIn</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Asha Natraj</span>
-							<span class="long-title">Gestionnaire GI/TI - Projet de conformité à l'accessibilité /
-								sensibilisation</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:asha.natraj@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/roch.jpg" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Roch Lambert</span>
-							<span class="long-title">Gestionnaire GI/TI - Stratégie et vérification d’accessibilité des
-								TIC (SVATIC)</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Professionnel certifi&eacute; en accessibilit&eacute; web (CPWA - IAAP)</li>
-								<li><a href="https://centreforinclusivedesign.org.au/index.php/pcwa/">UNSW certificat
-										professionnel en accessibilit&eacute; web</a></li>
-								<li>Professionnel certifié en compétences essentielles d'accessibilité (CPACC)</li>
-								<li>Spécialiste de l'accessibilité du Web (WAS)</li>
-								<li>Spécialiste des documents accessibles (ADS)</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:roch.lambert@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-								<li><a href="https://twitter.com/rlambert27"><i
-											class="fab fa-twitter fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Twitter</span></i></a></li>
-								<li><a href="https://www.linkedin.com/in/rlambert27/"><i
-											class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
-												class="wb-inv">LinkedIn</span></i></a></li>
-								<li><a href="https://github.com/rlambert27"><i
-											class="fab fa-github fa-lg mrgn-rght-sm"><span
-												class="wb-inv">GitHub</span></i></a></li>
-								<li><a href="https://www.accessibilityassociation.org/professionaldirectory"><i
-											class="fa fa-certificate fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Certificate</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Titus Cristea</span>
-							<span class="long-title">Gestionnaire GI/TI - Centre d'excellence en l'accessibilité
-								(CEA)</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:titus.cristea@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-								<li><a href="https://www.linkedin.com/in/titus-cristea-mpa-pmp-32a68b4/"><i
-											class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
-												class="wb-inv">LinkedIn</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				
-			</section>
-
-
-			<section class="col-xs-12 brdr-tp mrgn-tp-lg">
-				<h2 class="text-center mrgn-bttm-lg">L'équipe complète</h2>
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/andre-lorena.jpg" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Andrea Pachon</span>
-							<span class="title">Adjointe Administrative</span>
-						</div>
-						<div class="info">
-							<ul>
-
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:andrea.l.pachon@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Alexis van den Hoogen</span>
-							<span class="title">Chef d'équipe intérimaire</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Comit&eacute; international de qualification du test logiciel (ISTQB en anglais) -
-									Certifi&eacute; au niveau de la fondation</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:alexis.vandenhogen@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Andrew Nordlund</span>
-							<span class="title">Conseiller technique en accessibilit&eacute;</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Baccalaur&eacute;at ès sciences en informatique</li>
-								<li>Sp&eacute;cialiste de l'accessibilit&eacute; du Web (WAS)</li>
-								<li>Expert certifi&eacute; NVDA</li>
-								<li>D&eacute;veloppeur web</li>
-								<li>D&eacute;veloppeur d'extensions de navigateurs web</li>
-							</ul>
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:andrew.nordlund@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-								<li><i class="fab fa-linkedin fa-lg mrgn-rght-sm"></i><a
-										href="https://www.linkedin.com/in/andrew-nordlund-52607734"><span
-											class="wb-inv">LinkedIn</span></a></li>
-								<li><a href="https://github.com/andrewnordlund/"><i
-											class="fab fa-github fa-lg mrgn-rght-sm"><span
-												class="wb-inv">GitHub</span></i></a></li>
-								<li><a href="https://www.accessibilityassociation.org/s/wascertificants#Certificants3"><i
-											class="fa fa-certificate fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Certificate</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/anne.jpg" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Anne Simard</span>
-							<span class="title">Conseiller technique en accessibilit&eacute;</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Programme de certificat en applications de technologie d'assistance (ATACP) –
-									Universit&eacute; Northride le l’&eacute;tat de la Californie/2018</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><i class="fab fa-linkedin fa-lg mrgn-rght-sm"></i><a
-										href="https://www.linkedin.com/in/anne-simard-6b117a45"><span
-											class="wb-inv">LinkedIn</span></a></li>
-								<li><a href="mailto:anne.simard@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-								<li><a href="https://mobile.twitter.com/dragonlady0405"><i
-											class="fab fa-twitter fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Twitter</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Byatris Kattackal</span>
-							<span class="title">Conseiller technique en accessibilit&eacute;</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Professionnel certifi&eacute; en comp&eacute;tences essentielles en matière
-									d'accessibilit&eacute;</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:byatris.kattackal@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Delphine Gilbert-Laurendeau</span>
-							<span class="title">Analyste, Services soutien secteur TI</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Professionnelle certifi&eacute;e en comp&eacute;tences essentielles en matière
-									d'accessibilit&eacute;</li>
-								<li>Sp&eacute;cialiste des documents accessibles (<abbr
-										title="Sp&eacute;cialiste des documents accessibles">SDA</abbr>)</li>
-								<li>Programmeuse et designer web</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><i class="fab fa-linkedin fa-lg mrgn-rght-sm"></i><a
-										href="https://www.linkedin.com/in/dgilbertlaurendeau/"><span
-											class="wb-inv">LinkedIn</span></a></li>
-								<li><a href="delphine.gilbertlaurendeau@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Fr&eacute;dy D&eacute;monl&eacute; Moko</span>
-							<span class="title">Conseiller technique intérimaire en accessibilit&eacute;</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Étudiant à la maîtrise en gestion des technologies de l'information (M. Sc.)</li>
-								<li>Bachelier ès sciences appliqu&eacute;es, Informatique</li>
-								<li>Accessibilit&eacute; web</li>
-								<li>Analytique web</li>
-								<li>Programmation</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:fredy.demonlemoko@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-								<li><a href="https://github.com/fredymoko"><i
-											class="fab fa-github fa-lg mrgn-rght-sm"><span
-												class="wb-inv">GitHub</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Jolanta Szulc</span>
-							<span class="title">Analyste, Services soutien secteur TI</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Baccalaur&eacute;at en sciences informatiques</li>
-								<li>Professionnel certifi&eacute; en accessibilit&eacute; web (CPACC - IAAP)</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:jolanta.szulc@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Kelly-Ann Lauzon</span>
-							<span class="title">Agente, Services de projets</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:kellyanne.lauzon@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Miles King</span>
-							<span class="title">Analyste, Services soutien secteur TI</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:miles.h.king@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Nicolas Raymond</span>
-							<span class="title">Chef d’&eacute;quipe</span>
-						</div>
-						<div class="info">
-							<ul>
-								<li>Accessibilit&eacute; Web</li>
-							</ul>
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:nicolas.raymond@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Pierre Larochelle</span>
-							<span class="title">Analyste, Services soutien secteur TI</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:pierre.r.larochelle@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Sylvie Patry</span>
-							<span class="title">Analyste, Services soutien secteur TI</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="sylvie.patry@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">St&eacute;phane Mallette</span>
-							<span class="title">Analyste, Services soutien secteur TI</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:stephane.mallette@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Val&eacute;rie Auger</span>
-							<span class="title">Coordinateur de l'accessibilit&eacute; informatique</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:valerie.auger@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-				<div class="col-xs-12 col-sm-6 col-md-4">
-					<div class="team-member">
-						<div class="photo-container">
-							<img src="../images/placeholder.png" alt="">
-						</div>
-						<div class="text">
-							<span class="name">Wenjun Tang</span>
-							<span class="title">Analyste, Services soutien secteur TI</span>
-						</div>
-						<div class="info">
-
-						</div>
-						<div class="social">
-							<ul class="list-unstyled list-inline">
-								<li><a href="mailto:wenjun.tang@hrsdc-rhdcc.gc.ca"><i
-											class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
-												class="wb-inv">Courriel</span></i></a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-
-			</section>
-
-		</div>
-
-		<div id="def-preFooter"></div>
-		<script src="../../scripts/preFooter.min.js"></script>
-	</main>
-	<div id="def-footer"></div>
-	<script src="../../scripts/appFooter-fr.min.js"></script>
-	<script src="../../scripts/refFooter.min.js"></script>
-	<script src="../../scripts/bati-itao.min.js"></script>
-</body>
-
-</html>
+<!--[if lt IE 9]>
+<html class="no-js lt-ie9" lang="fr" dir="ltr">
+   <![endif]-->
+   <!--[if gt IE 8]><!-->
+   <html class="no-js" lang="fr" dir="ltr">
+      <!--<![endif]-->
+      <head>
+         <meta charset="utf-8">
+         <!-- Web Experience Toolkit (WET) / Boîte à outils de l'exp&eacute;rience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+         <title>L'équipe du bureau de l’accessibilité de la TI - EDSC / Bureau de l’accessibilit&eacute; de la TI</title>
+         <meta content="width=device-width,initial-scale=1" name="viewport">
+         <!-- Meta data -->
+         <meta name="description"
+            content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieu du travail.">
+         <!-- Meta data-->
+         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="../../scripts/refTop.min.js"></script>
+         <link rel="stylesheet" href="../../css/style.css">
+         <link rel="stylesheet" href="../styles/custom.css">
+      </head>
+      <body vocab="https://schema.org/" typeof="WebPage">
+         <div id="def-top">
+         </div>
+         <script>
+            var defTop = document.getElementById("def-top");
+            defTop.outerHTML = wet.builder.appTop({
+            	"appName": [{
+            		"text": "EDSC / Bureau de l’accessibilit&eacute; de la TI",
+            		"href": "../../index-fr.html"
+            	}],
+            	"breadcrumbs": [{
+            		"title": "Accueil",
+            		"href": "../../index-fr.html"
+            	}],
+            	"lngLinks": [{
+            		"lang": "en",
+            		"href": "./index-en.html",
+            		"text": "English"
+            	}],
+            	"menuPath": "../../ajax/menu-fr.html"
+            });
+         </script>
+         <main role="main" property="mainContentOfPage" class="container">
+            <h1 property="name" id="wb-cont">L'&eacute;quipe de bureau l’accessibilit&eacute; de la TI (<abbr
+               title="L'&eacute;quipe de bureau l’accessibilit&eacute; de la TI ">ITAO</abbr>)</h1>
+            <div class="row wb-eqht wb-init wb-eqht-inited mrgn-tp-lg">
+            <section class="col-xs-12">
+               <h2 class="text-center mrgn-bttm-lg">Équipe de direction</h2>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Andre Demers</span>
+                        <span class="title">Directeur intérimaire - Bureau d'accessibilité TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:andre.demers@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                           <li><a href="https://www.linkedin.com/in/andre-demers-6a196820/"><i
+                              class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">LinkedIn</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Asha Natraj</span>
+                        <span class="long-title">Gestionnaire GI/TI - Projet de conformité à l'accessibilité / sensibilisation</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:asha.natraj@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/roch.jpg" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Roch Lambert</span>
+                        <span class="long-title">Gestionnaire GI/TI - Stratégie et vérification d’accessibilité des TIC (SVATIC)</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Professionnel certifi&eacute; en accessibilit&eacute; web (CPWA - IAAP)</li>
+                           <li><a href="https://centreforinclusivedesign.org.au/index.php/pcwa/">UNSW certificat
+                              professionnel en accessibilit&eacute; web</a>
+                           </li>
+                           <li>Professionnel certifié en compétences essentielles d'accessibilité (<abbr
+                              title="Professionnel certifié en compétences essentielles d'accessibilité">CPACC</abbr>)</li>
+                           <li>Spécialiste de l'accessibilité du Web (<abbr
+                              title="Spécialiste de l'accessibilité du Web">WAS</abbr>)</li>
+                           <li>Spécialiste des documents accessibles (<abbr
+                              title="Spécialiste des documents accessibles">ADS</abbr>)</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:roch.lambert@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                           <li><a href="https://twitter.com/rlambert27"><i
+                              class="fab fa-twitter fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Twitter</span></i></a></li>
+                           <li><a href="https://www.linkedin.com/in/rlambert27/"><i
+                              class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">LinkedIn</span></i></a></li>
+                           <li><a href="https://github.com/rlambert27"><i
+                              class="fab fa-github fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">GitHub</span></i></a></li>
+                           <li><a href="https://www.accessibilityassociation.org/professionaldirectory"><i
+                              class="fa fa-certificate fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Certificate</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Titus Cristea</span>
+                        <span class="long-title">Gestionnaire GI/TI - Centre d'excellence en l'accessibilité (CEA)</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Professionnel certifié en compétences essentielles d'accessibilité (<abbr
+                              title="Professionnel certifié en compétences essentielles d'accessibilité">CPACC</abbr>)</li>
+                           <li>PMP - Project Management Professional</li>
+                           <li>PR2P - Prince2 Foundation and Practitioner Certified</li>
+                           <li>ITIL Foundation Certified</li>
+                           <li>MPA - Master of Public Administration (Management) - University of Quebec (ENAP)</li>
+                           <li>B.Eng - Bachelier en ingénierie informatique</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:titus.cristea@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                           <li><a href="https://www.linkedin.com/in/titus-cristea-mpa-pmp-32a68b4/"><i
+                              class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">LinkedIn</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/andre-lorena.jpg" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Andrea Pachon</span>
+                        <span class="title">Adjointe Administrative</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:andrea.l.pachon@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+            </section>
+            <section class="col-xs-12 brdr-tp mrgn-tp-lg">
+               <h2 class="text-center mrgn-bttm-lg">L'équipe Stratégie et vérification d’accessibilité des TIC (SVATIC)</h2>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Alexis van den Hoogen</span>
+                        <span class="title">Chef d'équipe intérimaire / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Comité international de qualification du test logiciel (<abbr
+                              title="Comité international de qualification du test logiciel">ISTQB en anglais</abbr>) - Certifi&eacute; au niveau de la fondation</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:alexis.vandenhogen@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/anne.jpg" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Anne Simard</span>
+                        <span class="title">Conseillère technique en accessibilit&eacute; / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Programme de certificat en applications de technologie d'assistance (<abbr
+                              title="Programme de certificat en applications de technologie d'assistance">ATACP en anglais</abbr>) - Universit&eacute; Northride le l’&eacute;tat de la Californie (<abbr
+                              title="Universit&eacute; Northride le l’&eacute;tat de la Californie">CSUN</abbr>) /2018
+                           </li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:anne.simard@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Andrew Nordlund</span>
+                        <span class="title">Conseiller technique en accessibilit&eacute; / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:andrew.nordlund@hrsdc-rhdcc.gc.ca"></a><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Ala Hamada</span>
+                        <span class="long-title">Conseillère technique en accessibilit&eacute;, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>L'accessibilité du Web</li>
+                           <li>L'accessibilité des documents</li>
+                           <li>J'ai aussi une certaine expérience avec les logiciels d'accessibilité.</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:ala.hamada@hrsdc-rhdcc.gc.ca"></a><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                           <li><a href="https://www.linkedin.com/in/alahamada/"><i
+                              class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">LinkedIn</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Brendan Carroll</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:brendan.carroll@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Byatris Kattackal</span>
+                        <span class="title">Conseillère technique en accessibilit&eacute; / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Professionnel certifié en compétences essentielles d'accessibilité (<abbr
+                              title="Professionnel certifié en compétences essentielles d'accessibilité">CPACC</abbr>)</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:byatris.kattackal@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Balakanthan Ratnam</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:balakanthan.ratnam@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Charlie Iro-Young</span>
+                        <span class="title">Technicien de support</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:charlie.iroyoung@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Delphine Gilbert-Laurendeau</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Professionnel certifié en compétences essentielles d'accessibilité (<abbr
+                              title="Professionnel certifié en compétences essentielles d'accessibilité">CPACC</abbr>)</li>
+                           <li>Spécialiste de l'accessibilité du Web (WAS)</li>
+                           <li>Sp&eacute;cialiste des documents accessibles (<abbr
+                              title="Sp&eacute;cialiste des documents accessibles">SDA</abbr>)</li>
+                           <li>Accessibilité des documents et du web</li>
+                           <li>Programmeuse et designer web</li>
+                           <li>Design graphique</li>
+                           <li>Spécialiste de SharePoint</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><i class="fab fa-linkedin fa-lg mrgn-rght-sm"></i><a
+                              href="https://www.linkedin.com/in/dgilbertlaurendeau/"><span
+                              class="wb-inv">LinkedIn</span></a></li>
+                           <li><a href="delphine.gilbertlaurendeau@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Dominic MacMillan</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:dominic.macmillan@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Frank Basham</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:frank.basham@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Fr&eacute;dy D&eacute;monl&eacute; Moko</span>
+                        <span class="long-title">Conseiller technique intérimaire en accessibilit&eacute; / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Étudiant à la maîtrise en gestion des technologies de l'information (M. Sc.)</li>
+                           <li>Bachelier ès sciences appliqu&eacute;es, Informatique</li>
+                           <li>Accessibilit&eacute; web</li>
+                           <li>Analytique web</li>
+                           <li>Programmation</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:fredy.demonlemoko@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                           <li><a href="https://github.com/fredymoko"><i
+                              class="fab fa-github fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">GitHub</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Jean-Michel Dorais</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:jeanmichel.dorais@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Jolanta Szulc</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Baccalaur&eacute;at en sciences informatiques</li>
+                           <li>Professionnel certifi&eacute; en accessibilit&eacute; web (<abbr
+                              title="Professionnel certifi&eacute; en accessibilit&eacute; web">CPACC</abbr>) - IAAP</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:jolanta.szulc@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span 				class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Kellyanne Lecuyer</span>
+                        <span class="title">Technicienne de soutien</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Programmeuse et designer Web</li>
+                           <li>Accessibilit&eacute; Web</li>
+                           <li>Design Graphique</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:kellyanne.lecuyer@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span 	class="wb-inv">Courriel</span></i></a></li>
+                           <li><a href="https://github.com/kellyanne-lecuyer/"><i
+                              class="fab fa-github fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">GitHub</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Larry Bowden</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Comité international de qualification du test logiciel (<abbr
+                              title="Comité international de qualification du test logiciel">ISTQB en anglais</abbr>) - Certifi&eacute;</li>
+                           <li>Accessibilité des documents</li>
+                           <li>Audio et vidéo accessibles</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:larry.bowden@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span 	class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Maxim Martel</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:maxim.martel@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span 	class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Maxim Perry</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Spécialiste de l'accessibilité du Web (<abbr
+                              title="Spécialiste de l'accessibilité du Web">WAS</abbr>)</li>
+                           <li>Accessibilité du Web</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:maxim.perry@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                           <li><a href="https://twitter.com/PerryMaxim"><i
+                              class="fab fa-twitter fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Twitter</span></i></a></li>
+                           <li><a href="https://www.linkedin.com/in/maxim-perry/"><i
+                              class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">LinkedIn</span></i></a></li>
+                           <li><a href="https://github.com/MaximPerry"><i
+                              class="fab fa-github fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">GitHub</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Miles King</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:miles.h.king@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Nicholas Atkins</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:nicholas.atkins@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Nicolas Raymond</span>
+                        <span class="title">Chef d’&eacute;quipe, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Professionnel certifié en compétences essentielles d'accessibilité (<abbr
+                              title="Professionnel certifié en compétences essentielles d'accessibilité">CPACC</abbr>)</li>
+                           <li>Accessibilit&eacute; Web</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:nicolas.raymond@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Olga Maximova</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Spécialiste de l'accessibilité du Web (<abbr
+                              title="Spécialiste de l'accessibilité du Web">WAS</abbr>)</li>
+                           <li>Accessibilit&eacute; Web</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:olga.maximova@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Sean Toogood</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:sean.toogood@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">St&eacute;phane Mallette</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:stephane.mallette@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Email</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Sylvie Patry</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="sylvie.patry@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Omar Touma</span>
+                        <span class="title">Sr Advisor, Infrastructure/Ops</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Certified Professional in Accessibility Core Competencies (<abbr
+                              title="Certified Professional in Accessibility Core Competencies">CPACC</abbr>)</li>
+                           <li>Web programmer</li>
+                           <li>Web designer</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:omar.touma@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Email</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Val&eacute;rie Auger</span>
+                        <span class="long-title">Coordinatrice de l'accessibilit&eacute; informatique</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:valerie.auger@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Wenjun Tang</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:wenjun.tang@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+            </section>
+            <section class="col-xs-12 brdr-tp mrgn-tp-lg">
+               <h2 class="text-center mrgn-bttm-lg">L'équipe Projet de conformité à l'accessibilité / sensibilisation</h2>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Abhishek Bothra</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:abhishek.bothra@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Annie Tremblay</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:annie.tremblay@servicecanada.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Cathy Teixeira</span>
+                        <span class="title">Chef d’équipe par intérim, Analyste</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Promotion de l’accessibilité par le biais d’articles et de sessions de sensibilisation</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:cathy.teixeira@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Christine  Poirier</span>
+                        <span class="title">Agente, Services des projets</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:christine.poirier@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Claude Bertrand</span>
+                        <span class="title">Consultant / Gestionnaire de projet</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:claude.bertrand@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Jeffery Orchard</span>
+                        <span class="long-title">Consultant / Coach en accessibilité</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Maîtrise, IM</li>
+                           <li>Accessibilité numérique</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:jeffery.orchard@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">John Avudria</span>
+                        <span class="title">Consultant</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:john.avudria@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Joshua Malette</span>
+                        <span class="title">Technicien de support</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:joshua.malette@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Kelly-Anne Lauzon</span>
+                        <span class="title">Agente, Services de projets</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:kellyanne.lauzon@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Kevin Cain</span>
+                        <span class="long-title">Chef d'équipe / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:kevin.cain@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Michael Chan</span>
+                        <span class="long-title">Consultant / Coach en Accessibilité</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Ingénierie informatique (B.A.Sc)</li>
+                           <li>Accessibilité du Web</li>
+                           <li>Accessibilité des documents</li>
+                           <li>Technologies d'assistance</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:michael.chan@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                           <li><a href="http://www.linkedin.com/in/michaelychan1"><i
+                              class="fab fa-linkedin fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">LinkedIn</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Micheline Dib</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:micheline.dib@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Minaxi Patel</span>
+                        <span class="long-title">Consultant/ Loan to iService**</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:minaxi.patel@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Mohammed Qadeer</span>
+                        <span class="long-title">Consultant / Coach en Accessibilité</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:mohammed.quadeer@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Pierre Larochelle</span>
+                        <span class="title">Analyste, Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:pierre.r.larochelle@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Richa Sharma</span>
+                        <span class="long-title">Agente / Service de projet</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:richa.sharma@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Rudolfo Lamontagne</span>
+                        <span class="long-title">Agent / Service de projet</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:rudolfo.lamontagne@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+            </section>
+            <section class="col-xs-12 brdr-tp mrgn-tp-lg">
+               <h2 class="text-center mrgn-bttm-lg">L'équipe Centre d'excellence en l'accessibilité (CEA)</h2>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Annie-Claude Chapleau</span>
+                        <span class="title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:annieclaude.chapleau@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Chantal Basque</span>
+                        <span class="title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:chantal.basque@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Hamza Lyazidi</span>
+                        <span class="long-title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Matériel d'assistance</li>
+                           <li>Gestion des ordinateurs</li>
+                           <li>Product management**</li>
+                           <li>PowerShell</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:hamza.lyazidi@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Jean-Pierre Larose</span>
+                        <span class="long-title">Chef d'équipe / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Professionnel certifié en compétences essentielles d'accessibilité (<abbr
+                              title="Professionnel certifié en compétences essentielles d'accessibilité">CPACC</abbr>)</li>
+                           <li>Support AT</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:jeanpierre.larose@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Joel Collin</span>
+                        <span class="long-title">Conseiller technique intérimaire / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Expert en basse vision, cognitive, malentendante</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:joel.collin@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Liban Darar</span>
+                        <span class="long-title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Administration des réseaux Cisco</li>
+                           <li>Spécialiste des technologies d'assistance</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:liban.darar@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Luis Fernandez</span>
+                        <span class="long-title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Professionnel certifié en compétences essentielles d'accessibilité (<abbr
+                              title="Professionnel certifié en compétences essentielles d'accessibilité">CPACC</abbr>)</li>
+                           <li>Certifié Zoomtext</li>
+                           <li>Certifié JAWS</li>
+                           <li>Soutien et dépannage</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:luisraciel.fernandez@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Marc-André Ferron</span>
+                        <span class="long-title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Technologie Support produit et support technique pour les clients ayant des problèmes de mobilité</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:marc.a.ferron@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Martin Villeneuve</span>
+                        <span class="long-title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:martin.m.villeneuve@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Michel Cormier</span>
+                        <span class="long-title">Chef d'équipe / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Professionnel certifié en compétences essentielles d'accessibilité (<abbr
+                              title="Professionnel certifié en compétences essentielles d'accessibilité">CPACC</abbr>)</li>
+                           <li>Certification JAWS</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:michel.cormier@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Sébastien St-Pierre-Dufour</span>
+                        <span class="long-title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Accessibilité pour les handicaps cognitifs et les malentendants</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:sebastien.stpierredufour@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Stephane Bonneville</span>
+                        <span class="long-title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Sylvain B&eacute;langer</span>
+                        <span class="long-title">Analyste / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                        <ul>
+                           <li>Expert en basse vision</li>
+                        </ul>
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:sylvain.d.belanger@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-xs-12 col-sm-6 col-md-4 ">
+                  <div class="team-member">
+                     <div class="photo-container">
+                        <img src="../images/placeholder.png" alt="">
+                     </div>
+                     <div class="text">
+                        <span class="name">Viviane Aoud</span>
+                        <span class="long-title">Conseiller technique intérimaire / Services soutien secteur TI</span>
+                     </div>
+                     <div class="info">
+                     </div>
+                     <div class="social">
+                        <ul class="list-unstyled list-inline">
+                           <li><a href="mailto:viviane.aouad@hrsdc-rhdcc.gc.ca"><i
+                              class="fa fa-envelope-open fa-lg mrgn-rght-sm" aria-hidden="true"><span
+                              class="wb-inv">Courriel</span></i></a></li>
+                        </ul>
+                     </div>
+                  </div>
+               </div>
+            </section>
+            <div id="def-preFooter"></div>
+            <script src="../../scripts/preFooter.min.js"></script>
+         </main>
+         <div id="def-footer"></div>
+         <script src="../../scripts/appFooter.min.js"></script>
+         <script src="../../scripts/refFooter.min.js"></script>
+         <script src="../../scripts/bati-itao.min.js"></script>
+      </body>
+   </html>


### PR DESCRIPTION
Remarks:

Text overflow for Titus Cristea;
Some squares for each person are longer/shorter;
Some icons are now purple or black instead of dark blue;
ACE team have 1 row that is different than the rest;
In FR, I don't know how to translate: Loan to iService, Sr Advisor, Infrastructure/Ops, and Product management. (I never received an FR document for the team page, so maybe other translations that are weird)