### PR TITLE
fixed mod7 colour page, left menu underlined link

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/module7/colour-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/colour-fr.html
@@ -344,9 +344,7 @@
                         <div class="panel-body">
                            <h2 class="text-success mrgn-tp-0 h3" id="simple-header"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp; Bon exemple : Bouton avec CSS</h2>
                            <p>Dans cet exemple, l’apparence du bouton est réglée avec les règles CSS, y compris les couleurs. Les valeurs peuvent facilement être remplacées par une feuille de style utilisateur personnalisée</p>
-                           <style>
-                              a {
-                              text-decoration: underline !important; }
+                           <style>                              
                               .button {
                               background-color: #f44336; /* Dark red */
                               border: none;

--- a/learning/esdc-self-paced-web-accessibility-course/module7/colour.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/colour.html
@@ -345,9 +345,7 @@
                         <div class="panel-body">
                            <h2 class="text-success mrgn-tp-0 h3" id="simple-header"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp; Good example: Button using CSS</h2>
                            <p>In this example, the appearance of the button is set with CSS rules, including colours. The values are easily overridden by a custom user style sheet.</p>
-                           <style>
-                              a {
-                              text-decoration: underline !important; }
+                           <style>                        
                               .button {
                               background-color: #f44336; /* Dark red */
                               border: none;


### PR DESCRIPTION
fixed mod7 colour.html and colour-fr.html page
- removed style for link in the example that was affecting left menu nav links