### PR TITLE
mods 1-5 example begins/ends message

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/module1/types-of-disabilities-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/types-of-disabilities-fr.html
@@ -277,13 +277,17 @@ $(function(){
 				<p>Image originale&nbsp;:</p>
 				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
 						<img src="images/image6.png" class="img-responsive" alt="Un diagramme a bandes utilisant les couleurs vert, bleu et rouge.">
+						<p class="wb-inv">Fin de l'exemple</p>
 					</div>
 				</div>
 				<p>Protanopia (red colour blind) simulation:</p>
 				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
 						<img src="images/image7.png" class="img-responsive" alt="Avec un filtre de protanopie, les couleurs rouge et vert transforment en deux teintes brunes. ">
+						<p class="wb-inv">Fin de l'exemple</p>
 					</div>
 				</div>
                	<div class="panel panel-success">
@@ -293,7 +297,9 @@ $(function(){
 						<p>Dans cet exemple, des motifs de fond sont utilisés pour identifier les trois catégories x, y et z. La couleur ne véhicule plus uniquement le sens.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<img src="images/image5.png" class="img-responsive" alt="Un diagramme a bandes avec des motifs de fond.">
+						<p class="wb-inv">Fin de l'exemple</p>
 							</div>
 						</div>
 					</div>

--- a/learning/esdc-self-paced-web-accessibility-course/module1/types-of-disabilities.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/types-of-disabilities.html
@@ -171,7 +171,7 @@ $(function(){
         <header class="panel-heading">
           <h2 class="panel-title"  >Table of contents</h2>
         </header>
-        <div class="panel-body" aria-label="Table of contents">
+        <div class="panel-body">
           <ul>
             <li><a href="#blind">Blind</a></li>
               <li><a href="#low-vision">Low vision</a></li>
@@ -506,15 +506,19 @@ $(function(){
 				<p>In the colour blindness simulation below, the red and green columns of the bar chart are barely distinguishable. The solution here is adding a background pattern, but the bars could also be labelled with visible text.</p>
 				<h3>Simulation of red-green colour blindness</h3>
 				<p>The original image:</p>
-				<div class="panel panel-primary mrgn-tp-md">
+				<div class="panel panel-primary mrgn-tp-lg">
 					<div class="panel-body mrgn-bttm-0">
+						<p class="wb-inv">Example begins</p>
 						<img src="images/image6.png" class="img-responsive" alt=" A bar chart using green, blue and red bars.">
+						<p class="wb-inv">Example ends</p>
 					</div>
 				</div>
 				<p>Protanopia (red colour blind) simulation:</p>
 				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body mrgn-bttm-0">
+						<p class="wb-inv">Example begins</p>
 						<img src="images/image7.png" class="img-responsive" alt=" With the protanopia filter, the red and green colours become similarly brown. ">
+						<p class="wb-inv">Example ends</p>
 					</div>
 				</div>
                 
@@ -524,7 +528,9 @@ $(function(){
 						<p>In this example, background patterns are used to identify the three categories x, y and z. Colour is no longer solely communicating the meaning.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
-								<img src="images/image5.png" class="img-responsive" alt="">
+								<p class="wb-inv">Example begins</p>
+									<img src="images/image5.png" class="img-responsive" alt="">
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 					</div>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/best-practice-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/best-practice-fr.html
@@ -61,7 +61,7 @@
 		
 		<h1 property="name" id="wb-cont">Pratiques exemplaires</h1>
 		<nav role="navigation"  aria-label="Table des matières">
-		  <div class="panel panel-default mrgn-tp-md">
+		  <div class="panel panel-default mrgn-tp-lg">
 			<header class="panel-heading">
 			  <h2 class="panel-title">Table des matières</h2>
 			</header>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/best-practice.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/best-practice.html
@@ -61,7 +61,7 @@
 		
 				<h1 property="name" id="wb-cont">Best practice</h1>
 												<nav role="navigation"  aria-label="Table of contents">
-      <div class="panel panel-default mrgn-tp-md">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table of contents</h2>
         </header>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/content-structure-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/content-structure-fr.html
@@ -63,7 +63,7 @@
 		<h1 property="name" id="wb-cont">Structure du contenu</h1>
 			
 	<nav role="navigation"  aria-label="Table of contents">
-      <div class="panel panel-default mrgn-tp-md">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table des matières</h2>
         </header>
@@ -122,12 +122,14 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Bon exemple&nbsp;1&nbsp;: Citation longue</h3>
 						<p>Utilisez l’élément <code>&lt;blockquote&gt;</code> pour des citations plus longues et plus complexes. Il peut contenir des paragraphes, des en-têtes et d’autres éléments de structure de texte. Ces éléments doivent refléter la structure du document cité. L’élément <code>&lt;cite&gt;</code> est utilisé pour indiquer la source de la citation.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<p>Voici une définition du <cite>Concept de structure de page</cite> tirée de W3&nbsp;WAI.</p>
 								<blockquote>
 									<p>Le contenu bien structuré permet une navigation et un traitement plus efficaces. Utiliser HTML et WAI-ARIA pour améliorer la navigation et l’orientation sur les pages Web et dans les applications.</p>
 								</blockquote>	
+								<p class="wb-inv">Fin de l'exemple</p>
 								<p class="wb-inv">Code commence</p>
 <pre>
 <code class="�language-html"�>&lt;p&gt;Voici une définition du &lt;cite&gt;Concept de structure de page&lt;/cite&gt; tirée de W3&nbsp;WAI.&lt;/p&gt;
@@ -144,9 +146,11 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Bon exemple&nbsp;2&nbsp;: Citation incluse par référence</h3>
 						<p>Pour les citations plus courtes, qui sont habituellement intégrées à une autre phrase, utiliser l’élément <code>&lt;q&gt;</code>.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<p>Helen&nbsp;Keller a affirmé&nbsp;: <q>«&nbsp;Notre pitié est notre pire ennemi et si nous y cédons, nous ne pourrons jamais rien faire de bien au monde&nbsp;»</q>.</p>
+								<p class="wb-inv">Fin de l'exemple</p>
 							</div>
 						</div>
 						<p class="wb-inv">Code commence</p>			
@@ -175,10 +179,12 @@ Le volume des ventes de notre produit PearlyTooth a été stable au cours des tr
 			<section>				<h2 id="tags">Balises strong (gras) et em (italique)</h2>
 				<p><code>STRONG</code> et <code>EM</code> sont des balises sémantiques qui signifient que l’auteur souhaite mettre des éléments en relief; ceux­ci seront affichés en gras (<code>&lt;strong&gt;</code>) ou en italique (<code>&lt;em&gt;</code>) dans un navigateur visuel. Les éléments <code>&lt;b&gt;</code> et <code>&lt;i&gt;</code> ne doivent pas être utilisés.</p>
 				<p>Les éléments <code>&lt;strong&gt;</code> et <code>&lt;em&gt;</code> sont souvent utilisés pour mettre en évidence des mots ou des phrases dans un paragraphe de texte. Par exemple&nbsp;:</p>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
 						<p>«&nbsp;<strong>Important</strong>&nbsp;: J’aimerais être avisé par courriel, pas par d’autres formes de communication.&nbsp;»</p>
 						<p>«&nbsp;Son livre préféré est <em>Les raisins de la colère.&nbsp;»</em></p>
+						<p class="wb-inv">Fin de l'exemple</p>
 					</div>
 				</div>
 				<p>La prise en charge de <code>&lt;strong&gt;</code> et <code>&lt;em&gt;</code> par le lecteur d’écran est faible. </p>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/content-structure.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/content-structure.html
@@ -63,7 +63,7 @@
 	<h1 property="name" id="wb-cont">Content structure</h1>
 			
 						<nav role="navigation"  aria-label="Table of contents">
-      <div class="panel panel-default mrgn-tp-md">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table of contents</h2>
         </header>
@@ -125,15 +125,17 @@
 				<div class="panel-body">
 					<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Good example 1: Blockquote</h3>
 					<p>Use the <code>&lt;blockquote&gt;</code> element for longer and more complex quotes. It can contain paragraphs, headings, and other text structure elements. Those should reflect the structure of the cited document. The <code>&lt;cite&gt;</code> element is used to refer to the source of the quote.</p>
-					<div class="panel panel-primary">
+					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">Example begins</p>
 							<p>The following is a definition on <cite>Page Structure Concept</cite> from W3 WAI.</p>
 							<blockquote>
 								<p>Well-structured content allows more efficient navigation and processing. Use HTML and WAI-ARIA to improve navigation and orientation on web pages and in applications.</p>
 							</blockquote>
+							<p class="wb-inv">Example ends</p>
 						</div>
 					</div>
-							<p class="wb-inv">Code begins</p>
+					<p class="wb-inv">Code begins</p>
 <pre>
 <code class="language-html">&lt;p&gt;The following is a definition on &lt;cite&gt;Page Structure Concept&lt;/cite&gt; from W3 WAI.&lt;/p&gt;
 &lt;blockquote&gt;
@@ -141,15 +143,19 @@
 &lt;/blockquote&gt;</code>
 </pre>
 <p class="wb-inv">Code ends</p>
+						
+					
 				</div>
 		</div>
 		<div class="panel panel-success">
 				<div class="panel-body">
 					<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Good example 2: Inline quote</h3>
 					<p>For shorter quotes, that are usually embedded in another sentence, use the <code>&lt;q&gt;</code> element.</p>
-					<div class="panel panel-primary">
+					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">Example begins</p>
 							<p>Helen Keller said, <q>"Self-pity is our worst enemy and if we yield to it, we can never do anything good in the world."</q></p>
+							<p class="wb-inv">Example ends</p>
 						</div>
 					</div>
 					<p class="wb-inv">Code begins</p>			
@@ -179,10 +185,12 @@
 		<h2 id="tags">Strong (bold) and em (italics) tags</h2>
 		<p><code>STRONG</code> and <code>EM</code> are semantic tags meaning the author wishes to provide emphasis, which is rendered as bold (<code>&lt;strong&gt;</code>) or italic (<code>&lt;em&gt;</code>) on a visual browser. The <code>&lt;b&gt;</code> and <code>&lt;i&gt;</code> elements should not be used.</p>
 		<p>The <code>&lt;strong&gt;</code> and <code>&lt;em&gt;</code> elements are often used to highlight words or phrases in a paragraph of text. For example:</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<p>"<strong>Important:</strong> I would like to be notified by email, not other forms of communication."</p>
 				<p>"His favorite book is <em>The Grapes of Wrath</em>."</p>
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		<p>Screen reader support for <code>&lt;strong&gt;</code> and <code>&lt;em&gt;</code> is weak. </p>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/headings-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/headings-fr.html
@@ -63,7 +63,7 @@
 			
 			<h1 property="name" id="wb-cont">En-têtes</h1>
 			<nav role="navigation"  aria-label="Table des matières">
-			  <div class="panel panel-default mrgn-tp-md">
+			  <div class="panel panel-default mrgn-tp-lg">
 				<header class="panel-heading">
 				  <h2 class="panel-title">Table des matières</h2>
 				</header>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/headings.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/headings.html
@@ -63,7 +63,7 @@
 			
 		<h1 property="name" id="wb-cont">Headings</h1>
 		<nav role="navigation"  aria-label="Table of contents">
-		  <div class="panel panel-default mrgn-tp-md">
+		  <div class="panel panel-default mrgn-tp-lg">
 			<header class="panel-heading">
 			  <h2 class="panel-title">Table of contents</h2>
 			</header>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/landmarks-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/landmarks-fr.html
@@ -64,7 +64,7 @@
 			
 		<h1 property="name" id="wb-cont">Points de repère</h1>
 		<nav role="navigation"  aria-label="Table des matières">
-		  <div class="panel panel-default mrgn-tp-md">
+		  <div class="panel panel-default mrgn-tp-lg">
 			<header class="panel-heading">
 			  <h2 class="panel-title">Table des matières</h2>
 			</header>
@@ -238,7 +238,9 @@
 &lt;footer aria-label="footer"&gt;…&lt;/footer&gt;</code>
 </pre>
 								<p class="wb-inv">Fins du code</p>
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<img src="images/image1.png" class="img-responsive" alt=" Un diagramme démontre les zones relatives des points de répère.">
+								<p class="wb-inv">Fin de l'exemple</p>
 							</div>
 						</div>
 					</div>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/landmarks.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/landmarks.html
@@ -63,7 +63,7 @@
 			
 			<h1 property="name" id="wb-cont">Landmarks</h1>
 				<nav role="navigation"  aria-label="Table of contents">
-      <div class="panel panel-default mrgn-tp-md">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table of contents</h2>
         </header>
@@ -228,6 +228,7 @@
 						<p>In this example, HTML5 sectioning elements define the landmarks for the most part. The <code>role="search"</code> attribute is unique and descriptive, and the redundant <code>role="main"</code> supports the IE 11 browser.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<p class="wb-inv">Code begins</p>
 <pre><code class="language-html">&lt;header&gt;
    &lt;nav aria-label="global"&gt;…&lt;/nav&gt;
@@ -240,6 +241,7 @@
 </pre>
 								<p class="wb-inv">Code ends</p>
 								<img src="images/image1.png" class="img-responsive" alt=" Screenshot of landmark roles in their conventional locations. A header region holds nav and role=&#34;search&#34; landmarks. Below the header, left to right, are nav, main and aside landmarks. At the bottom is the footer landmark.">
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 					</div>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/language-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/language-fr.html
@@ -65,8 +65,8 @@
 	<main class="col-md-9 col-md-push-3"   role="main" property="mainContentOfPage">
 		<h1 property="name" id="wb-cont">Langue</h1>
 						
-						<nav role="navigation" aria-label="Table of contents">
-      <div class="panel panel-default mrgn-tp-md">
+						<nav role="navigation"  aria-label="Table of contents">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table des matières</h2>
         </header>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/language.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/language.html
@@ -65,8 +65,8 @@
 	<main class="col-md-9 col-md-push-3"   role="main" property="mainContentOfPage">
 		<h1 property="name" id="wb-cont">Language</h1>
 						
-						<nav role="navigation" aria-label="Table of contents">
-      <div class="panel panel-default mrgn-tp-md">
+						<nav role="navigation"  aria-label="Table of contents">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table of contents</h2>
         </header>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/lists-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/lists-fr.html
@@ -63,8 +63,8 @@
 		
 	<h1 property="name" id="wb-cont">Listes</h1>
 									
-	<nav role="navigation"   aria-label="Table des matières">
-      <div class="panel panel-default mrgn-tp-md">
+	<nav role="navigation"  aria-label="Table des matières">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table des matières</h2>
         </header>
@@ -96,8 +96,9 @@
 			</section>
 			<section>				<h2 id="unordered-list">Liste non ordonnée</h2>
 				<p>La liste non ordonnée comprend un élément <code>&lt;ul&gt;</code> et plusieurs éléments de liste (<code>&lt;li&gt;</code>):</p>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<ul>
 								<li>Maïs</li>
 								<li>Tomates</li>
@@ -105,7 +106,7 @@
 								<li>Oignons</li>
 								<li>Ail</li>
 							</ul>
-			
+							<p class="wb-inv">Fin de l'exemple</p>			
 				 		</div>
 				</div>
 				 <p class="wb-inv">Code commence</p>
@@ -124,8 +125,9 @@
 				<h2 id="ordered-list">Liste ordonnée</h2>
 				<p>La liste ordonnée comprend un élément <code>&lt;ol&gt;</code> et plusieurs éléments de liste (<code>&lt;li&gt;</code>):</p>
 				<p>Utilisez des listes ordonnées (<code>&lt;ol&gt;</code>) pour des renseignements séquentiels, lorsque l'ordre des éléments est pertinent. Chaque élément de liste (<code>&lt;li&gt;</code>) est numéroté par le navigateur.</p>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<ol>
 								<li>Cuire les haricots pendant 45 minutes.</li>
 								<li>Couper les légumes en petits cubes.</li>
@@ -133,6 +135,7 @@
 								<li>Déglacer avec les tomates.</li>
 								<li>Ajouter le maïs et les haricots.</li>
 							</ol>
+							<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 				</div>
 				<p class="wb-inv">Code commence</p>
@@ -151,8 +154,9 @@
 			<section>
 				<h2 id="nested-lists">Listes imbriquées</h2>
 				<p>Chaque liste peut être imbriquée dans une autre liste. Dans l’exemple suivant, l’ordre de préparation n’est pas critique, mais la préparation elle-même doit être effectuée avant d’utiliser les ingrédients. L’information est encore facile à assimiler, et la technologie d’assistance peut facilement informer les utilisateurs du nombre d’étapes.</p>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<ol>
 								<li>Préparer les ingrédients
 									<ul>
@@ -164,6 +168,7 @@
 								<li>Déglacer avec les tomates.</li>
 								<li>Ajouter le maïs et les haricots</li>
 							</ol>
+							<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 				</div>
 				<p class="wb-inv">Code commence</p>
@@ -189,14 +194,16 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Bon exemple 1 : Un terme, plusieurs descriptions</h3>
 						<p>Dans l’exemple qui suit, John et Luke sont décrits comme auteurs et Frank comme éditeur.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<dl>  
 								<dt>Auteurs</dt>
 								 <dd>John</dd>  
 								<dd>Luke</dd>
 								  <dt>Éditeur</dt>  
 								<dd>Frank</dd></dl>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<p class="wb-inv">Code commence</p>
@@ -217,13 +224,15 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Bon exemple 2 : Termes multiples, une description</h3>
 						<p>Dans l’exemple suivant, deux variantes orthographiques d’un mot sont définies au moyen de listes de descriptions. Dans de tels cas, utiliser l’élément  <code>&lt;dfn&gt;</code> pour marquer le terme défini.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<dl>   
 									<dt lang="en-US"><dfn>color</dfn></dt>
 									<dt lang="en-GB"><dfn>colour</dfn></dt>
 									<dd>A sensation which (in humans) derives from the ability of the fine structure of the eye to distinguish three differently filtered analyses of a view.</dd>
 								</dl>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 								<p class="wb-inv">Code commence</p>
@@ -241,14 +250,16 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Bon exemple 3 : Termes multiples, descriptions multiples</h3>
 						<p>Dans cet exemple, John et Luke sont des auteurs et également des éditeurs :</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<dl>
 									<dt>Auteurs</dt> 
 									<dt>Éditeurs</dt>
 									<dd>John</dd>  
 									<dd>Luke</dd>
 								</dl>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<p class="wb-inv">Code commence</p>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/lists.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/lists.html
@@ -63,8 +63,8 @@
 		
 	<h1 property="name" id="wb-cont">Lists</h1>
 									
-						<nav role="navigation"   aria-label="Table of contents">
-      <div class="panel panel-default mrgn-tp-md">
+						<nav role="navigation"  aria-label="Table of contents">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table of contents</h2>
         </header>
@@ -97,8 +97,9 @@
 			<section>
 				<h2 id="unordered-list">Unordered list</h2>
 				<p>The unordered list consists of one <code>&lt;ul&gt;</code> element and multiple list item (<code>&lt;li&gt;</code>) elements:</p>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">Example begins</p>
 						<ul>
 							<li>Corn</li>
 							<li>Tomatoes</li>
@@ -106,6 +107,7 @@
 							<li>Onions</li>
 							<li>Garlic</li>
 						</ul>
+						<p class="wb-inv">Example ends</p>
 					</div>
 				</div>
 				<p class="wb-inv">Code begins</p>
@@ -123,8 +125,9 @@
 				<h2 id="ordered-list">Ordered list</h2>
 				<p>The ordered list consists of one <code>&lt;ol&gt;</code> element and multiple list item (<code>&lt;li&gt;</code>) elements:</p>
 				<p>Use ordered lists (<code>&lt;ol&gt;</code>) for sequential information, when the order of the items is relevant. Each list item (<code>&lt;li&gt;</code>) is numbered by the browser.</p>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">Example begins</p>
 						<ol>
 							<li>Cook beans for 45 minutes.</li>
 							<li>Cut vegetables in small cubes.</li>
@@ -132,6 +135,7 @@
 							<li>Deglaze using the tomatoes.</li>
 							<li>Add corn and beans.</li>
 						</ol>
+						<p class="wb-inv">Example ends</p>
 					</div>
 				</div>
 				<p class="wb-inv">Code begins</p>
@@ -149,8 +153,9 @@
 			<section>
 				<h2 id="nested-lists">Nested lists</h2>
 				<p>Every list can be nested into another list. In the following example, the order of preparation is not critical, but the preparation itself should be done before using the ingredients. The information is still easy to digest, assistive technology can easily inform users about the number of steps.</p>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">Example begins</p>
 						<ol>
 							<li>Prepare ingredients
 								<ul>
@@ -162,6 +167,7 @@
 							<li>Deglaze using the tomatoes.</li>
 							<li>Add corn and beans.</li>
 						</ol>
+						<p class="wb-inv">Example ends</p>
 					</div>
 				</div>
 				<p class="wb-inv">Code begins</p>
@@ -187,8 +193,9 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Good example 1: One term, multiple descriptions</h3>
 						<p>In the following example, John and Luke are described as authors, and Frank is described as editor.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<dl>  
 									<dt>Authors</dt>
 									 <dd>John</dd>  
@@ -196,6 +203,7 @@
 									  <dt>Editor</dt>  
 									<dd>Frank</dd>
 								</dl>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<p class="wb-inv">Code begins</p>
@@ -214,13 +222,15 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Good example 2: Multiple terms, one description</h3>
 						<p>In the next example, two different spellings of a word are defined using description lists. In such cases, use the <code>&lt;dfn&gt;</code> element to mark up the defined term.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<dl>   
 									<dt lang="en-US"><dfn>color</dfn></dt>
 									<dt lang="en-GB"><dfn>colour</dfn></dt>
 									<dd>A sensation which (in humans) derives from the ability of the fine structure of the eye to distinguish three differently filtered analyses of a view.</dd>
 								</dl>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<p class="wb-inv">Code begins</p>
@@ -237,14 +247,16 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span> Good example 3: Multiple terms, multiple descriptions</h3>
 						<p>In this example, John and Luke are authors and also editors:</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<dl>
 									<dt>Authors</dt> 
 									<dt>Editors</dt>
 									<dd>John</dd>  
 									<dd>Luke</dd>
 								</dl>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 								<p class="wb-inv">Code begins</p>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/parsing-and-validity-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/parsing-and-validity-fr.html
@@ -65,7 +65,7 @@
 	<h1 property="name" id="wb-cont">Analyse syntaxique et validité</h1>
 						
 	<nav role="navigation"  aria-label="Table des matières">
-      <div class="panel panel-default mrgn-tp-md">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table des matières</h2>
         </header>

--- a/learning/esdc-self-paced-web-accessibility-course/module2/parsing-and-validity.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/parsing-and-validity.html
@@ -65,7 +65,7 @@
 	<h1 property="name" id="wb-cont">Parsing and validity</h1>
 						
 									<nav role="navigation"  aria-label="Table of contents">
-      <div class="panel panel-default mrgn-tp-md">
+      <div class="panel panel-default mrgn-tp-lg">
         <header class="panel-heading">
           <h2 class="panel-title">Table of contents</h2>
         </header>

--- a/learning/esdc-self-paced-web-accessibility-course/module3/links-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/links-fr.html
@@ -63,8 +63,8 @@
 		
 	<h1 property="name" id="wb-cont">Liens</h1>
 		                
-                	<nav role="navigation" aria-label="Table des matières">
-      <div class="panel panel-default mrgn-tp-md">
+                	<nav role="navigation"  aria-label="Table des matières">
+      <div class="panel panel-default mrgn-tp-lg">
 			<header class="panel-heading">
 				<h2 class="panel-title">Table des matières</h2>
 			</header>
@@ -111,11 +111,13 @@
 						</h3>
 						<p>Dans cet exemple, le texte du lien «&nbsp;la quantité&nbsp;» ne communique rien d’utile&nbsp;:</p>
 						
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<blockquote>
 									<p>Une portion du Guide alimentaire est simplement une quantité de référence. Elle vous aide à comprendre <a href="https://guide-alimentaire.canada.ca/fr/">la quantité</a> recommandée chaque jour pour les quatre groupes alimentaires. Dans certains cas, une portion du Guide alimentaire peut se rapprocher de ce que vous mangez, comme une pomme. Dans d’autres cas, comme le riz ou les pâtes, vous pouvez vous servir davantage que la portion du Guide alimentaire.</p>
 								</blockquote>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 					</div>
@@ -126,14 +128,16 @@
 							<span class="glyphicon glyphicon-ok-circle"></span>&nbsp;Bon exemple : Texte de lien descriptif
 						</h3>
 						<p>Dans cet exemple, la fonction du lien est parfaitement claire.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<blockquote>
 									<p>Le Guide alimentaire sert à déterminer la quantité d’aliments que vous devriez consommer chaque jour dans chacun des quatre groupes alimentaires. Dans certains cas, une portion correspond à la quantité d’un groupe alimentaire donné que vous consommez normalement en une seule fois, comme une pomme. Dans d’autres cas, la quantité quotidienne représente plus d’une portion, comme pour le riz ou les pâtes.</p>
 									<p>
 										<a href="https://guide-alimentaire.canada.ca/fr/">Nombre de portions alimentaires quotidiennes pour les enfants, les adolescents et les adultes</a>
 									</p>
 								</blockquote>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 					</div>
@@ -362,14 +366,16 @@
 					<div class="panel-body">
 						<h3 class="text-danger mrgn-tp-0"><span class="glyphicon glyphicon-remove-circle"></span>&nbsp;Mauvais exemple&nbsp;: Suppression de l’indicateur visuel de la cible</h3>
 						<p>Tous les navigateurs affichent un contour visible autour de l’élément qui a actuellement cible de clavier et qui peut être désactivé en utilisant la propriété CSS <code>outline: 0</code> ou <code>outline: none</code>. Si l’indicateur visuel de la cible est supprimé, les utilisateurs du clavier voyants n’auront aucune idée du lien qui a la cible, ce qui rend difficile ou impossible la navigation dans la page Web.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<p>Un lien vers <a href="http://www.google.ca" id="google">Google</a></p>
 								<style type="text/css">
 									a#google:focus {
 										outline:none;
 									}
 								</style>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<p class="wb-inv">Code commence</p>

--- a/learning/esdc-self-paced-web-accessibility-course/module3/links.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/links.html
@@ -114,11 +114,13 @@
 					<div class="panel-body">
 						<h3 class="text-danger mrgn-tp-0"><span class="glyphicon glyphicon-remove-circle"></span>&nbsp;Bad Example: Vague link text</h3>
 						<p>In this example, the link text &ldquo;<q>how much</q>&rdquo;communicates nothing useful:</p>
-						<div class="panel panel-primary">
-							<div class="panel-body well mrgn-bttm-0">	
+						<div class="panel panel-primary mrgn-tp-md">
+							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>	
 								<blockquote>
 									<p>A Food Guide Serving is simply a reference amount. It helps you understand <a href="http://www.hc-sc.gc.ca/fn-an/food-guide-aliment/basics-base/quantit-eng.php">how much</a> food is recommended every day from each of the four food groups. In some cases, a Food Guide Serving may be close to what you eat, such as an apple. In other cases, such as rice or pasta, you may serve yourself more than one Food Guide Serving.</p>
 								</blockquote>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 					</div>
@@ -127,14 +129,16 @@
 					<div class="panel-body">
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp;Good example: Descriptive link text</h3>
 						<p>In this example, the purpose of the link is perfectly clear.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<blockquote>
 									<p>A Food Guide serving is how much food you should eat from each of the 4 food groups every day. In some cases, a serving is the amount of a given food group that you normally eat in one sitting, like an apple. In other cases, the daily amount is more than one serving, such as for rice or pasta.</p>
 									<p>
 										<a href="http://www.hc-sc.gc.ca/fn-an/food-guide-aliment/basics-base/quantit-eng.php">Number of daily food servings for children, teens and adults</a>
 									</p>
 								</blockquote>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 					</div>
@@ -360,14 +364,16 @@
 					<div class="panel-body">
 						<h3 class="text-danger mrgn-tp-0"><span class="glyphicon glyphicon-remove-circle"></span>&nbsp;Bad example: Visual focus indicator is removed</h3>
 						<p>All browsers display a visible outline around the element that currently has keyboard focus, which can be disabled using the <code>outline: 0</code> or <code>outline: none</code> CSS property. If the visual focus indicator is removed, sighted keyboard users will have no idea which link has the focus, making it difficult or impossible to navigate the web page.</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<p>A link to <a href="http://www.google.ca" id="google">Google</a></p>
 								<style type="text/css">
 									a#google:focus {
 										outline:none;
 									}
 								</style>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<p class="wb-inv">Code begins</p>

--- a/learning/esdc-self-paced-web-accessibility-course/module3/navigation-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/navigation-fr.html
@@ -232,8 +232,10 @@
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp;Bon exemple&nbsp;: Passer au contenu principal</h3>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<img src="images/image2.png" class="img-responsive" alt="Capture d’écran du bureau de l’accessibilité des TI d’EDSC montrant un lien «&nbsp;Passer au contenu principal&nbsp;» au haut de la page.">
 								<img src="images/image3.png" class="img-responsive" alt="Capture d’écran du code source. Le lien de saut est un article d’une liste, dans un élément nav avec l’étiquette «&nbsp;Skip links&nbsp;».">
+								<p class="wb-inv">Fin de l'exemple</p>
 							</div>
 						</div>
 					</div>
@@ -284,7 +286,9 @@
 						<p>Dans cet exemple, une saisie d’écran d’une table des matières montre le texte d’en-tête sous forme de liens. Les en-têtes des niveaux&nbsp;1, 2 et&nbsp;3 sont inclus.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<img src="images/image4.png" class="img-responsive" alt="Capture d’écran d’une table des matières montrant le texte d’en-tête sous forme de liens.">
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 					</div>
@@ -394,6 +398,7 @@
 						</ul>
 						<div class="panel panel-primary mrgn-tp-lg">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<a href="http://www.bing.com" class="link">Bing</a> 
 								<a href="http://www.duckduckgo.com" class="link">DuckDuckGo</a> 
 								<span 
@@ -404,6 +409,7 @@
 									onkeydown="goToLink(event, 'goToLink(event, 'http://www.google.ca/')">
 										Google
 								</span>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">
@@ -507,14 +513,16 @@
 &lt;/div&gt;</code>
 </pre>
 						<p class="wb-inv">Fins du code</p>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<button type="button" onclick="document.getElementById('target').focus();">
 									Cliquez sur moi pour cibler la DIV
 								</button>
 								<div id="target" tabindex="-1">
 									Je suis une div
 								</div>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 					</div>
@@ -540,9 +548,11 @@
 							<li>Un objet mystère sans fonctionnalité et sans indicateur de cible visible (<code>tabindex="4"</code>)</li>
 							<li>“More travel”, puis suit l’ordre naturel des onglets (<code>tabindex="0"</code>).</li>
 						</ul>
-						<div class="panel panel-primary">
+						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<img src="images/image7.png" class="img-responsive" alt="Capture d’écran montrant l’ordre des onglets sur une page.">
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						

--- a/learning/esdc-self-paced-web-accessibility-course/module3/navigation.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/navigation.html
@@ -233,8 +233,10 @@
 						<h3 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp;Good example: Skip to main content</h3>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<img src="images/image2.png" class="img-responsive" alt=" &#34;Screenshot of the ESDC IT Accessibility office showing a &#34;Skip to main content&#34; link at the top of the page.">
 								<img src="images/image3.png" class="img-responsive" alt=" &#34;Screenshot of the source code. The skip link is one item in a list, in a nav element with the label &#34;Skip links&#34;&#34;">
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 					</div>
@@ -284,7 +286,9 @@
 						<p>In this example, a screenshot of a table of contents shows heading text as links. Headings of levels 1, 2 and 3 are included.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<img src="images/image4.png" class="img-responsive" alt="Screenshot of a table of contents shows heading text as links.">
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 					</div>
@@ -389,6 +393,7 @@
 						</ul>
 						<div class="panel panel-primary mrgn-tp-lg">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<a href="http://www.bing.com" class="link">Bing</a> 
 								<a href="http://www.duckduckgo.com" class="link">DuckDuckGo</a> 
 								<span 
@@ -399,6 +404,7 @@
 									onkeydown="goToLink(event, 'http://www.google.ca/')">
 										Google
 								</span>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">
@@ -489,14 +495,16 @@
 					<div class="panel-body">
 						<h4 class="text-success mrgn-tp-0"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp;Good example: Element with tabindex="-1" receives focus by script</h4>
 						<p>In this example, clicking the button sets focus on the <code>div</code> element. </p>
-						<div class="panel panel-primary">
-							<div class="panel-body well mrgn-bttm-0">				
+						<div class="panel panel-primary mrgn-tp-md">
+							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>				
 								<button type="button" onclick="document.getElementById('target').focus();">
 									Click on me to focus the DIV
 								</button>
 								<div id="target" tabindex="-1">
 									I am a div
 								</div>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<p class="wb-inv">Code begins</p>
@@ -526,9 +534,11 @@
 							<li>A mystery object that has no functionality, and no visible focus indicator (<code>tabindex="4"</code>)</li>
 							<li>"More travel" and then follows the natural tab order (<code>tabindex="0"</code>).</li>
 						</ul>
-						<div class="panel panel-primary">
-							<div class="panel-body mrgn-bttm-0">				
+						<div class="panel panel-primary mrgn-tp-md">
+							<div class="panel-body mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>				
 								<img src="images/image7.png" class="img-responsive" alt="Screenshot showing the tab order on a page">
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						

--- a/learning/esdc-self-paced-web-accessibility-course/module4/caption-summary-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/caption-summary-fr.html
@@ -97,6 +97,7 @@
 					<p>Dans cet exemple, «&nbsp;Films à l’affiche&nbsp;» indique aux utilisateurs quelle information se trouve dans le tableau.</p>
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<table class="table table-bordered table-hover">
 								<caption>Films à l’affiche</caption>
 								<tr>
@@ -120,6 +121,7 @@
 									<td>Cineplex London</td>
 								</tr>
 							</table>
+							<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 					</div>
 					<details class="mrgn-tp-lg">
@@ -180,6 +182,7 @@
 					<p>Dans l’exemple ci-dessous, le tableau complexe montre le nombre d’étudiants inscrits dans deux pays pendant quatre semestres. L’élément <code>&lt;caption&gt;</code> sert d’en-tête du tableau et fournit un sommaire décrivant la structure du tableau.</p>
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<table class="table table-bordered table-hover">
 							  <caption>
 								Renseignements sur le nombre d’étudiants inscrits
@@ -245,6 +248,7 @@
 								</tr>
 							  </tbody>
 							</table>
+							<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 					</div>
 					<details class="mrgn-tp-lg">
@@ -345,6 +349,7 @@
 						
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<figure>
 									  <figcaption>
 										<strong id="studentinfo-caption">Informations sur le nombre d’étudiants inscrits</strong>
@@ -388,6 +393,7 @@
 									  </tbody>
 									  </table>
 								</figure>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/caption-summary.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/caption-summary.html
@@ -98,6 +98,7 @@
 					<p>In this example &ldquo;Movies Releases&rdquo; tells users what information is in the table.</p>
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">Example begins</p>
 							<table class="table table-bordered table-hover">
 								<caption>Movies Releases</caption>
 								<tr>
@@ -121,6 +122,7 @@
 									<td>Cineplex London</td>
 								</tr>
 							</table>
+							<p class="wb-inv">Example ends</p>
 						</div>
 					</div>
 					<details class="mrgn-tp-lg">
@@ -183,6 +185,7 @@
 					<p>In the example below, the complex table shows the number of students enrolled in two countries across four semester seasons. The <code>&lt;caption&gt;</code> element acts as a heading for the table and provides a summary that describes the structure of the table.</p>
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">Example begins</p>
 							<table class="table table-bordered table-hover">
 							  <caption>
 								Information on number of students enrolled
@@ -248,6 +251,7 @@
 								</tr>
 							  </tbody>
 							</table>
+							<p class="wb-inv">Example ends</p>
 						</div>
 					</div>
 					<details class="mrgn-tp-lg">
@@ -348,6 +352,7 @@
 						<p>The summary paragraph in the <code>&lt;figcaption&gt;</code> element is explicitly associated with the table using the <code>aria-describedby</code> attribute.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<figure>
 									  <figcaption>
 										<strong id="studentinfo-caption">Information on number of students enrolled</strong>
@@ -391,6 +396,7 @@
 									  </tbody>
 									  </table>
 								</figure>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/irregular-headers-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/irregular-headers-fr.html
@@ -94,6 +94,7 @@
 			<p>Pour les en-têtes de rangée solo, ajouter l’attribut <code>scope="row"</code> à l’élément <code>&lt;th&gt;</code>. Voir les en-têtes&nbsp;<strong>B1</strong> et <strong>B2</strong> dans le tableau ci-dessous.</p>
 			<div class="panel panel-primary mrgn-tp-md">
 				<div class="panel-body well mrgn-bttm-0">
+					<p class="wb-inv">D&eacute;but de l'exemple</p>
 					<table class="table table-bordered">
 					 <caption>Tableau comportant un en-tête de colonne et un en-tête de rangée</caption>
 							  <tr class="bg-primary">
@@ -119,6 +120,7 @@
 								<td>&nbsp;</td>
 							  </tr>
 					</table>
+					<p class="wb-inv">Fin de l'exemple</p>	
 				</div>
 			</div>
 			<p>Le support du lecteur d’écran pour l’attribut <code>scope="rowgroup"</code> est pire que le support pour l’attribut <code>scope="colgroup"</code>. Lorsque cela est possible, concevoir des tableaux qui utilisent <code>scope="colgroup"</code> et éviter <code>scope="rowgroup"</code>.</p>
@@ -171,6 +173,7 @@
 					
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<table class="table table-bordered">
 								<col> 
 								<col> 
@@ -219,6 +222,7 @@
 									</tr> 
 								</tbody> 
 							</table>
+							<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 					</div>
 					<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/irregular-headers.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/irregular-headers.html
@@ -94,6 +94,7 @@
 			<p>For solo row headers, add the <code>scope="row"</code> attribute to the th element. See headers <strong>B1</strong>, <strong>B2</strong> in the example table below.</p>
 			<div class="panel panel-primary mrgn-tp-md">
 				<div class="panel-body well mrgn-bttm-0">
+					<p class="wb-inv">Example begins</p>
 					<table class="table table-bordered">
 					 <caption>Table with a column-spanning header and a row-spanning header</caption>
 							  <tr class="bg-primary">
@@ -119,6 +120,7 @@
 								<td>&nbsp;</td>
 							  </tr>
 					</table>
+					<p class="wb-inv">Example ends</p>
 				</div>
 			</div>
 			<p>Screen reader support for the <code>scope="rowgroup"</code> attribute is worse than support for <code>scope="colgroup"</code>. When possible, design tables to leverage <code>scope="colgroup"</code> and avoid <code>scope="rowgroup"</code>.</p>
@@ -168,6 +170,7 @@
 					<p>In this example, <mark><ins>"Country" and "Onwership" are solo columns, each identified with a <code>&lt;col&gt;</code> element. "Scenario" spans columns, identified with a <code>&lt;colgroup span="3"&gt;</code> element.</ins></mark> The "Canada" and "USA" headers and their respective rows are each nested in a <code>&lt;tbody&gt;</code> element. <del>he "Scenario" header is identified with a <code>&lt;colgroup span="3"&gt;</code> element.</del></p>
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">Example begins</p>
 							<table class="table table-bordered">
 								<col> 
 								<col> 
@@ -216,6 +219,7 @@
 									</tr> 
 								</tbody> 
 							</table>
+							<p class="wb-inv">Example ends</p>
 						</div>
 					</div>
 					<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/multi-level-headers-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/multi-level-headers-fr.html
@@ -102,6 +102,7 @@
 						<p>Dans cet exemple, les en-têtes de rangée sont empilés par trois, ce qui nécessite l’utilisation d’un balisage <code>id/header</code> pour associer les cellules de données à leurs en-têtes. Le <a href="https://wet-boew.github.io/v4.0-ci/demos/tablevalidator/tablevalidator-en.html">validateur de tableau BOEW</a> fournit le balisage <code>id/header</code>. Une description de tableau visuellement masquée est imbriquée dans la légende.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<table class="table small">
 									<caption>
 										éhicules loués par le gouvernement
@@ -170,7 +171,7 @@
 											 </td>
 										 </tr>
 										 <tr>
-											 <th id="tbl59" headers="tbl8">court terme/th>
+											 <th id="tbl59" headers="tbl8">court terme</th>
 											 <td headers="tbl9 tbl41 tbl53 tbl59">
 												 <p>tiliser la couverture d’assurance commerciale (responsabilité civile et collision pour les risques américains) administrée par le Secteur de la gestion des services et des acquisitions spécialisées. <abbr title="Travaux publics et Services gouvernementaux Canada">TPSGC</abbr>;</p> 
 												 <p>- s’auto-assurer pour la franchise -</p>
@@ -178,6 +179,7 @@
 										 </tr>
 									 </tbody>
 								</table>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">
@@ -294,6 +296,7 @@
 						<p>Le tableau de l’exemple précédent est trop complexe et nécessite une technique <code>id/header</code> difficilement prise en charge. Une meilleure approche consiste à diviser un tableau complexe en au moins deux tableaux plus petits. Dans cet exemple, le «&nbsp;Type de véhicule&nbsp;» (de fonction ou non) est déplacé de la colonne&nbsp;1 à la légende du tableau, ce qui aboutit à un tableau pour les véhicules de fonction et un deuxième tableau pour les véhicules qui ne sont pas des véhicules de fonction. Les tableaux plus simples sont composés de deux niveaux d’en-têtes; ils peuvent donc être rendus en utilisant l’attribut <code>scope</code> plutôt qu’en utilisant les attributs <code>id/header</code>. L'attribut <code>scope</code> est plus facile à rédiger et à tenir à jour, et elle est mieux prise en charge par les agents utilisateurs que la méthode <code>id/header</code>.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<table class="table table-bordered table-hover small">
 								   <!-- <caption>Non-executive Vehicles leased by the Government</caption> -->
 								   <caption><mark>Véhicules non fonction loués par le gouvernement</mark></caption>
@@ -332,12 +335,13 @@
 									 <tr>
 									   <th scope="row">court terme</th>
 									   <td>
-										 <p>Utiliser la couverture d’assurance commerciale (responsabilité civile et collision pour les risques américains) administrée par le Secteur de la gestion des services et des acquisitions spécialisées. <abbr title="Travaux publics et Services gouvernementaux Canada"></abbr>TPSGC</abbr></p>
+										 <p>Utiliser la couverture d’assurance commerciale (responsabilité civile et collision pour les risques américains) administrée par le Secteur de la gestion des services et des acquisitions spécialisées. <abbr title="Travaux publics et Services gouvernementaux Canada">TPSGC</abbr></p>
 										 <p>- s’auto-assurer pour la franchise -</p>
 									   </td>
 									 </tr>
 								   </tbody>
 								</table>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">
@@ -405,6 +409,7 @@
 						
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<figure> 
 									<figcaption>  
 										<strong id="caption">Coût des produits biologiques et non biologiques, par pays</strong>  
@@ -465,6 +470,7 @@
 										</tbody>  
 									</table>  
 								</figure>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/multi-level-headers.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/multi-level-headers.html
@@ -102,6 +102,7 @@
 						<p>In this example, the row headers are three deep, requiring the use of <code>id/headers</code> markup to associate the data cells with their headers. The <a href="https://wet-boew.github.io/v4.0-ci/demos/tablevalidator/tablevalidator-en.html">WET Table Validator</a> provides the <code>id/headers</code> markup. A visually-hidden table description is nested in the <code>&lt;caption&gt;</code> element.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<table class="table small">
 									<caption>
 										Vehicles leased by the Government
@@ -170,6 +171,7 @@
 										 </tr>
 									 </tbody>
 								</table>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">
@@ -284,6 +286,7 @@
 						<p>The table in the previous example is overly complex, requiring the poorly-supported <code>id/headers</code> technique. A better approach is to split a complex table into two or more smaller tables. In this example, the “Type of Vehicle" (executive or non-executive) is moved from column 1 to the table caption, resulting in one table about executive vehicles and a second table about non-executive vehicles. The simpler tables consist of two levels of headers, so can be rendered using the <code>scope</code> attribute rather than with <code>id/headers</code> attributes. Scope is easier to author and maintain, and is better supported by user agents than the <code>id/headers</code> method.</p>		  
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<table class="table table-bordered table-hover small">
 								   <caption>Non-executive Vehicles leased by the Government</caption>
 								   <thead>
@@ -327,6 +330,7 @@
 									 </tr>
 								   </tbody>
 								</table>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">
@@ -390,6 +394,7 @@
 						<p>Note that the empty header cell is given an <code>id</code> attribute value and a non-breaking space as content. The cell is referenced by top-level headers in their <code>headers</code> attribute. This prevents some assistive technologies from declaring the cell.</p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<figure> 
 									<figcaption>  
 										<strong id="caption">Cost of organic vs non-organic produce in Canada, the USA and the UK</strong>  
@@ -450,6 +455,7 @@
 										</tbody>  
 									</table>  
 								</figure>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/one-header-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/one-header-fr.html
@@ -88,7 +88,8 @@
 					<div class="panel-body">
 						<h2 class="text-success mrgn-tp-0 h3" id="simple-header"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp; Bon exemple&nbsp;: Tableau simple avec des en-t&ecirc;tes de colonne</h2>	
 						<div class="panel panel-primary mrgn-tp-md">
-							<div class="panel-body well mrgn-bttm-0">			
+							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>			
 								<table class="table table-bordered table-hover">
 									<caption>Réunions de cette semaine</caption>
 								  <thead>
@@ -116,6 +117,7 @@
 									  </tr>
 									</tbody>
 								</table>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">
@@ -151,6 +153,7 @@
 						<h2 class="text-success mrgn-tp-0 h3" id="row-headers"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp; Bon exemple&nbsp;: Tableau simple avec en-têtes de rangée</h2>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">D&eacute;but de l'exemple</p>
 								<table class="table table-bordered table-hover">
 									<caption>Réunions de cette semaine</caption> 
 									<tbody> 
@@ -174,6 +177,7 @@
 									  </tr>
 									  </tbody>
 								</table>
+								<p class="wb-inv">Fin de l'exemple</p>	
 							</div>
 						</div>	
 						<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/one-header.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/one-header.html
@@ -89,7 +89,8 @@
 					<div class="panel-body">
 						<h2 class="text-success mrgn-tp-0 h3" id="simple-header"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp; Good example: Simple table with <mark><ins>column headers</ins></mark> <del>one simple header for row</del></h2>	
 						<div class="panel panel-primary mrgn-tp-md">
-							<div class="panel-body well mrgn-bttm-0">			
+							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>			
 								<table class="table table-bordered table-hover">
 									<caption>This week’s meetings</caption>
 								  <thead>
@@ -117,6 +118,7 @@
 									  </tr>
 									</tbody>
 								</table>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>
 						<details class="mrgn-tp-lg">
@@ -152,6 +154,7 @@
 						<h2 class="text-success mrgn-tp-0 h3" id="row-headers"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp; Good example: Simple table with row headers</h2>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body well mrgn-bttm-0">
+								<p class="wb-inv">Example begins</p>
 								<table class="table table-bordered table-hover">
 									<caption>This week’s meetings</caption> 
 									<tbody> 
@@ -175,6 +178,7 @@
 									  </tr>
 									  </tbody>
 								</table>
+								<p class="wb-inv">Example ends</p>
 							</div>
 						</div>	
 						<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/tables-resources-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/tables-resources-fr.html
@@ -64,7 +64,7 @@
 	
 			<h1 property="name" id="wb-cont">Ressources se rapportant aux tableaux dans la Boîte à outils de l’expérience Web (BOEW)</h1>
 			 <div class="panel panel-primary mrgn-tp-lg mrgn-bttm-lg">
-  <div class="panel-body well mrgn-bttm-0">			
+  <div class="panel-body well mrgn-bttm-0">		
 		
 			<p>Le  <a href="https://wet-boew.github.io/wet-boew-styleguide/design/tables-fr.html">guide de style de la BOEW pour les tableaux</a> décrit les différents effets visuels et interactifs des noms de classe des feuilles de style CSS de la BOEW.</p>
 			<p>Le  <a href="https://wet-boew.github.io/v4.0-ci/docs/ref/tables/tables-fr.html">plugiciel Tables de la BOEW</a> offre des fonctions de recherche, de tri, de filtrage, de pagination et d’autres fonctions avancées pour les tableaux. </p>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/two-headers-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/two-headers-fr.html
@@ -100,10 +100,11 @@
 					<p>Dans ce tableau, la colonne&nbsp;2 contient les cellules d’en-tête de la rangée. Les cellules de la colonne&nbsp;2 utilisent des éléments <code>&lt;th&gt;</code> et l’attribut <code>scope="row"</code>. Les cellules de la rangée&nbsp;1 sont également marquées <code>&lt;th&gt;</code> et utilisent <code>scope="col"</code>.</p>
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<table class="table table-bordered table-hover">
 							  <caption>
 								Congés de maladie pris au premier trimestre
-							  </caption >
+							  </caption>
 							  <thead>
 								<tr>
 								  <th scope="col"><abbr title="Identification">ID</abbr></th>
@@ -141,6 +142,7 @@
 							 
 							  </tbody>
 							</table>
+							<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 					</div>
 					<details class="mrgn-tp-lg">
@@ -195,10 +197,11 @@
 					<h2 class="text-success mrgn-tp-0 h3" id="table-into-lists"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp; Bon exemple&nbsp;: Conversion d’un tableau en listes</h2>	
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<table class="table table-bordered table-hover">
 							  <caption>
 								Congés de maladie pris au premier trimestre
-							  </caption >
+							  </caption>
 							  <thead>
 								<tr>
 								  <th scope="col"><abbr title="Identification">ID</abbr></th>
@@ -235,10 +238,12 @@
 								</tr>
 							  </tbody>
 							</table>
+							<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 					</div>
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<h3 class="mrgn-tp-0">Congés de maladie pris au premier trimestre</h3>
 							<h4>Janvier</h4>
 							<ul>
@@ -258,6 +263,7 @@
 							  <li>Andy (ID #561): 3</li>
 							  <li>Michelle (ID#765): 0</li>
 							</ul>
+							<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 					</div>
 				</div>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/two-headers.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/two-headers.html
@@ -99,11 +99,12 @@
 			
 					<p>In this table, column 2 contains the header cells for the row. The cells in column 2 use <code>&lt;th&gt;</code> elements and the <code>scope="row"</code> attribute. The cells in row 1 are also marked up with <code>&lt;th&gt;</code> and use <code>scope="col"</code>.</p>
 					<div class="panel panel-primary mrgn-tp-md">
-							<div class="panel-body well mrgn-bttm-0">
+						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">Example begins</p>
 							<table class="table table-bordered table-hover">
 							  <caption>
 								Sick days taken in the first quarter
-							  </caption >
+							  </caption>
 							  <thead>
 								<tr>
 								  <th scope="col"><abbr title="Identification">ID</abbr></th>
@@ -141,6 +142,7 @@
 							 
 							  </tbody>
 							</table>
+							<p class="wb-inv">Example ends</p>
 						</div>
 					</div>
 					<details class="mrgn-tp-lg">
@@ -195,10 +197,11 @@
 					<h2 class="text-success mrgn-tp-0 h3" id="table-into-lists"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp; Good example: Convert table into lists</h2>	
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">Example begins</p>
 							<table class="table table-bordered table-hover">
 							  <caption>
 								Sick days taken in the first quarter
-							  </caption >
+							  </caption>
 							  <thead>
 								<tr>
 								  <th scope="col"><abbr title="Identification">ID</abbr></th>
@@ -235,10 +238,12 @@
 								</tr>
 							  </tbody>
 							</table>
+							<p class="wb-inv">Example ends</p>
 						</div>
 					</div>
 					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+							<p class="wb-inv">Example begins</p>
 							<h3 class="mrgn-tp-0">Sick days taken in first quarter</h3>
 							<h4>January</h4>
 							<ul>
@@ -258,6 +263,7 @@
 							  <li>Andy (ID #561): 3</li>
 							  <li>Michelle (ID#765): 0</li>
 							</ul>
+							<p class="wb-inv">Example ends</p>
 						</div>
 					</div>
 				</div>

--- a/learning/esdc-self-paced-web-accessibility-course/module5/complex-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/complex-images-fr.html
@@ -100,9 +100,11 @@
 					<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Longue description contenant de l’information structurée</h3>
 				<p>Dans cet exemple, <code>alt</code>  le texte de remplacement se lit comme suit : “<q>« Histogrammes montrant l’activité physique selon trois groupes d’âge avant la COVID et pendant la COVID. Une longue description suit. </q>”. » La description longue fournit des renseignements détaillés, y compris les échelles, les valeurs, les relations et les tendances représentées visuellement. Par exemple, la description longue peut indiquer les valeurs décroissantes chez les jeunes, les valeurs constantes chez les adultes (18 à 64 ans) et les valeurs croissantes chez les adultes plus âgés.</p>
 				<p>Cet exemple inclut la description longue dans un gadget logiciel à bascule <code>&lt;détaillé&gt;</code> ou <code>&lt;sommaire&gt;</code> sous le graphique.</p>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
 						<img src="images/image19.png" class="img-responsive" alt="Histogrammes montrant l’activité physique selon trois groupes d’âge avant la COVID et pendant la COVID. La description du texte suit.">
+						<p class="wb-inv">Fin de l'exemple</p>	
 					</div>
 				</div>
 				<!-- <img src="images/image17.png" class="img-responsive" alt="">-->

--- a/learning/esdc-self-paced-web-accessibility-course/module5/complex-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/complex-images.html
@@ -98,9 +98,11 @@
 			<span class="glyphicon glyphicon-ok-circle"></span> Good example: Long description containing structured information</h3>
 		<p>In this example, the <code>alt</code> text reads “<q>Bar chart showing physical activity by three age groups pre-COVID and during COVID. Long description follows</q>”. The long description provides detailed information, including scales, values, relationships and trends that are represented visually. For example, the long description can point out the declining values for youth, consistent values for adults (18 to 64), and increasing values for older adults.</p>
 		<p>This example includes the long description in a <code>&lt;details&gt;</code>/<code>&lt;summary&gt;</code> toggle widget below the chart.</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
-				<img src="images/image19.png" class="img-responsive" alt="Bar chart showing physical activity by three age groups pre-COVID and during COVID. Long description follows,">
+				<p class="wb-inv">Example begins</p>
+				<img src="images/image19.png" class="img-responsive" alt="Bar chart showing physical activity by three age groups pre-COVID and during COVID. Long description follows.">
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>	
 		<!-- <img src="images/image17.png" class="img-responsive" alt="">-->

--- a/learning/esdc-self-paced-web-accessibility-course/module5/decorative-redundant-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/decorative-redundant-images-fr.html
@@ -112,10 +112,12 @@
 						<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple 2 : Image avec équivalent textuel adjacent redondant
 					</h2>
 					<p>L’image ci-dessous est déjà suffisamment décrite par le texte adjacent. Une valeur alt nulle (vide) peut être utilisée puisqu’il n’est pas nécessaire de répéter cette information.</p>
-					<div class="panel panel-primary">
+					<div class="panel panel-primary mrgn-tp-md">
 						<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
 							<img src="images/decorativeimg2.png"  alt="" class="img-responsive"/>
 							<p>À cette époque, un artiste de cirque pouvait contrôler trois chevaux avec leurs rênes, debout sur le dos d’un cheval.</p>
+						<p class="wb-inv">Fin de l'exemple</p>	
 						</div>
 					</div>
 					

--- a/learning/esdc-self-paced-web-accessibility-course/module5/figcaption-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/figcaption-fr.html
@@ -63,8 +63,8 @@
 
 	<h1 property="name" id="wb-cont">Figure et figcaption</h1>
 
-	<nav role="navigation" aria-label="Table des matières">
-		<div class="panel panel-default mrgn-tp-md">
+	<nav role="navigation"  aria-label="Table des matières">
+		<div class="panel panel-default mrgn-tp-lg">
 			<header class="panel-heading">
 				<h2 class="panel-title">Table des matières</h2>
 			</header>
@@ -103,12 +103,14 @@
 					<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Figure et figcaption
 				</h2>
 				
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
 						<figure>
 							<img class="img-responsive" alt="Maisons trullo (cabanes en pierre sèche) avec toit conique" src="images/image4.jpg"/>
 							<figcaption>Rangée de maisons trullo (cabanes en pierre sèche) sur la rue Monte Pertica à Alberobello, dans la province de Bari, en Italie</figcaption>
 						</figure>
+						<p class="wb-inv">Fin de l'exemple</p>	
 					</div>
 				</div>
 				

--- a/learning/esdc-self-paced-web-accessibility-course/module5/figcaption.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/figcaption.html
@@ -60,8 +60,8 @@
 	<main class="col-md-9 col-md-push-3"   role="main" property="mainContentOfPage">
 
 	<h1 property="name" id="wb-cont">Figure and figcaption</h1>
-	<nav role="navigation" aria-label="Table des matières">
-		<div class="panel panel-default mrgn-tp-md">
+	<nav role="navigation"  aria-label="Table des matières">
+		<div class="panel panel-default mrgn-tp-lg">
 			<header class="panel-heading">
 				<h2 class="panel-title">Table des matières</h2>
 			</header>
@@ -97,12 +97,14 @@
 					<span class="glyphicon glyphicon-ok-circle"></span> Good example: Figure and figcaption
 				</h2>
 				
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">Example begins</p>
 						<figure>
 							<img class="img-responsive" alt="Trullo houses (dry stone huts) with conical roof" src="images/image4.jpg"/>
 							<figcaption>Row of trullo houses (dry stone huts) on Monte Pertica street in Alberobello, Bari Province, Italy</figcaption>
 						</figure>
+						<p class="wb-inv">Example ends</p>
 					</div>
 				</div>
 				

--- a/learning/esdc-self-paced-web-accessibility-course/module5/functional-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/functional-images-fr.html
@@ -93,17 +93,17 @@
 					<h3 class="text-success mrgn-tp-0">
 			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Image liée</h3>
 		<p>Dans l’exemple ci-dessous, le logo Canada.ca de la bannière renvoie à la page d’accueil Canada.ca.  <code>&lt;img&gt;</code> L’élément est imbriqué dans le lien. Le texte de remplacement « Page d’accueil du gouvernement du Canada » fournit le texte du lien.</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 				<img src="images/image1f.png" class="img-responsive" alt="Page d’accueil du gouvernement du Canada">
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 		<p class="wb-inv">Code commence</p>
-<pre>
-<code class="language-html">&lt;a href="https://www.canada.ca/en.html"&gt;
-	&lt;img src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt="Page d’accueil du gouvernement du Canada"&gt;
-&lt;/a&gt;</code>
-</pre>
+<pre><code class="language-html">&lt;a href="https://www.canada.ca/en.html"&gt;
+   &lt;img src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt="Page d’accueil du gouvernement du Canada"&gt;
+&lt;/a&gt;</code></pre>
 		<p class="wb-inv">Fins du code</p>
 				</div>
 		</div>
@@ -112,21 +112,20 @@
 					<h3 class="text-success mrgn-tp-0">
 			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Icône avec texte de remplacement utile imbriqué dans le texte du lien</h3>
 		<p>Dans cet exemple, une icône avec le texte de remplacement utile « S’ouvre dans une nouvelle fenêtre » est imbriquée dans le lien avec le texte de lien « Page d’accueil du W3C ». Les utilisateurs du lecteur d’écran entendront « Page d’accueil du W3C, s’ouvre dans une nouvelle fenêtre ».</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 				<a href="https://www.w3.org/" target="_blank">Page d’accueil du W3C <img src="images/image1d.png" class="" alt="S’ouvre dans une nouvelle fenêtre">
 				</a>
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 		<p class="wb-inv">Code commence</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;a href="https://www.w3.org/" target="_blank"&gt; 
-	Page d’accueil du W3C 
-	&lt;img src="new-window.png" alt="S’ouvre dans une nouvelle fenêtre"&gt;
-&lt;/a&gt;</code>
-</pre>
-		</div>
+<pre><code class="language-html">&lt;a href="https://www.w3.org/" target="_blank"&gt; 
+   Page d’accueil du W3C 
+   &lt;img src="new-window.png" alt="S’ouvre dans une nouvelle fenêtre"&gt;
+&lt;/a&gt;</code></pre>
+
 		<p class="wb-inv">Fins du code</p>
 		<p>Remarque : Cette technique est souvent utilisée avec des icônes pour indiquer différents formats de fichier comme AVI, ODF, MP3, PDF, Word, etc. Dans ce cas, l’équivalent textuel doit transmettre le format représenté par chaque icône.</p>
 				</div>
@@ -136,19 +135,17 @@
 					<h3 class="text-success mrgn-tp-0">
 			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Icône fonctionnelle</h3>
 		<p>Dans cet exemple, une icône cliquable représentant une imprimante indique une fonction d’impression. Son équivalent textuel est « Imprimer cette page » plutôt que le mot littéral « Imprimante », car le but est d’activer la boîte de dialogue d’impression.</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 				<img src="images/image22.png" class="img-responsive" alt="Imprimer cette page">
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 		<p class="wb-inv">Code commence</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;a href="javascript:print()"&gt;
-	&lt;img src="print.png" alt="Imprimer cette page"&gt;
-&lt;/a&gt;</code>
-</pre>
-		</div>
+<pre><code class="language-html">&lt;a href="javascript:print()"&gt;
+   &lt;img src="print.png" alt="Imprimer cette page"&gt;
+&lt;/a&gt;</code></pre>
 		<p class="wb-inv">Fins du code</p>
 				</div>
 		</div>
@@ -158,46 +155,43 @@
 			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Image utilisée dans un bouton
 		</h3>
 		<p>L’image suivante est utilisée pour donner au bouton un style distinct. Dans ce cas, il s’agit du bouton permettant de lancer une demande de recherche, et l’icône imbriquée est une loupe. L’équivalent textuel de l’image est « Recherche », pour indiquer la fonction du bouton, plutôt que « loupe ».</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 				<label for="search">Recherche</label>
 				<input type="search" name="search"></input>
 				<input type="image" src="images/searchbutton.png" alt="Recherche" style="width: 1.5em">
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 		<p class="wb-inv">Code commence</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;input type="image" src="searchbutton.png" alt="Recherche"&gt;</code>
-</pre>
-		</div>
+<pre><code class="language-html">&lt;input type="image" src="searchbutton.png" alt="Recherche"&gt;</code></pre>
 		<p class="wb-inv">Fins du code</p>
 				</div>
 		</div>
 		<div class="panel panel-success">
-				<div class="panel-body">
-					<h3 class="text-success mrgn-tp-0">
-			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Image redondante dans le texte du lien</h3>
-		<p>Dans cet exemple, le logo de la société XYZ accompagne un lien texte qui mène à la page d’accueil de la société XYZ. L’image ne représente pas une fonctionnalité différente et ne transmet pas d’autres renseignements que ceux déjà fournis dans le texte du lien. En fait, l’image est une simple aide visuelle associée au texte du lien. Une valeur alt nulle (vide) est appliquée, (<code>alt=""</code>), pour éviter la redondance et la répétition.</p>
-		<div class="panel panel-primary">
-			<div class="panel-body well mrgn-bttm-0">
-				<a href="https://www.CompanyXYZ.ca/">
-					<img src="images/image2b.png" class="img-responsive" alt="">
-					Page d’accueil de la compagnie XYZ
-				</a>
-			</div>
-		</div>
-		<p class="wb-inv">Code commence</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;a href="https://www.CompanyXYZ.ca/"&gt;   
+			<div class="panel-body">
+				<h3 class="text-success mrgn-tp-0">
+					<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Image redondante dans le texte du lien
+				</h3>
+				<p>Dans cet exemple, le logo de la société XYZ accompagne un lien texte qui mène à la page d’accueil de la société XYZ. L’image ne représente pas une fonctionnalité différente et ne transmet pas d’autres renseignements que ceux déjà fournis dans le texte du lien. En fait, l’image est une simple aide visuelle associée au texte du lien. Une valeur alt nulle (vide) est appliquée, (<code>alt=""</code>), pour éviter la redondance et la répétition.</p>
+				<div class="panel panel-primary mrgn-tp-md">
+					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
+						<a href="https://www.CompanyXYZ.ca/">
+							<img src="images/image2b.png" class="img-responsive" alt="">
+							Page d’accueil de la compagnie XYZ
+						</a>
+						<p class="wb-inv">Fin de l'exemple</p>	
+					</div>
+				</div>
+				<p class="wb-inv">Code commence</p>
+<pre><code class="language-html">&lt;a href="https://www.CompanyXYZ.ca/"&gt;   
 	&lt;img src="logo.png" alt=""&gt;
 	Page d’accueil de la compagnie XYZ
-&lt;/a&gt;</code>
-</pre>
-		</div>
-		<p class="wb-inv">Fins du code</p>
-				</div>
+&lt;/a&gt;</code></pre>
+				<p class="wb-inv">Fins du code</p>
+			</div>
 		</div>
 	</section>
 	<section>
@@ -205,66 +199,65 @@
 		<p>Avec cette stratégie, une étiquette ARIA sur la commande fournit le nom accessible de l’image fonctionnelle. L’attribut <code>alt</code> de l’élément imbriqué  <code>&lt;img&gt;</code> est réglé sur null (vide) : <code>alt=""</code>.</p>
 		<p>L’attribut <abbr>alt</abbr> de l’élément enfant <code>&lt;img&gt;</code> pourrait contenir n’importe quelle valeur et cela n’aurait pas d’importance, car cette valeur serait supplantée par l’attribut <code>aria-label</code> ou <code>aria-labelledby</code>, qui a préséance sur le texte enfant lorsqu’on nomme une commande</p>
 		<div class="panel panel-success">
-				<div class="panel-body">
-					<h3 class="text-success mrgn-tp-0">
-			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Nommer une image fonctionnelle à l’aide de l’attribut <code>aria-label</code></h3>
-		<p>Dans cet exemple, un attribut <code>aria-label</code> nomme le bouton plutôt que l’attribut <code>alt</code> de l’élément enfant <code>&lt;img&gt;</code>. L’attribut <code>alt</code> est réglé sur null (vide)&nbsp;: <code>alt=""</code>.</p>
+			<div class="panel-body">
+				<h3 class="text-success mrgn-tp-0">
+					<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Nommer une image fonctionnelle à l’aide de l’attribut <code>aria-label</code>
+				</h3>
+				<p>Dans cet exemple, un attribut <code>aria-label</code> nomme le bouton plutôt que l’attribut <code>alt</code> de l’élément enfant <code>&lt;img&gt;</code>. L’attribut <code>alt</code> est réglé sur null (vide)&nbsp;: <code>alt=""</code>.</p>
+				
+				<button aria-label="Suivant">
+					<img src="images/image1e.png" class="img-responsive" alt="">
+				</button>
 		
-		<button aria-label="Suivant">
-			<img src="images/image1e.png" class="img-responsive" alt="">
-		</button>
-
-		<p class="wb-inv">Code commence</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;button aria-label="Suivant"&gt;
+				<p class="wb-inv">Code commence</p>
+<pre><code class="language-html">&lt;button aria-label="Suivant"&gt;
 	&lt;img src="images/next.png" alt=""&gt;
-&lt;/button&gt;</code>
-</pre>
-		</div>
-		<p class="wb-inv">Fins du code</p>
-				</div>
+&lt;/button&gt;</code></pre>
+
+				<p class="wb-inv">Fins du code</p>
+			</div>
 		</div>
 		<div class="panel panel-success">
-				<div class="panel-body">
-					<h3 class="text-success mrgn-tp-0">
-			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Nommer des images fonctionnelles à l’aide des attributs <code>aria-label</code> et <code>aria-labelled</code></h3>
-		<p>Dans cet exemple, chacun des deux boutons de formatage du texte est accompagné d’un bouton « More » (Lire la suite) identique. Les boutons de formatage sont nommés avec l’attribut <code>aria-label</code>. Les boutons « More » (Lire la suite) sont nommés avec l’attribut <code>aria-labelledby</code>, pointant vers les valeurs <code>id</code> des éléments contenant les fragments d’étiquette souhaités : « Lire la suite » + soit « Bullets » (Puces) soit « Text alignment » (Alignement du texte). L’attribut <code>alt</code> de chaque élément de bouton <code>&lt;img&gt;</code> est réglé sur null (vide) : <code>alt=””</code>.</p>
-		
-<div class="panel panel-primary">
-	<div class="panel-body mrgn-bttm-0">
-<div id="inline-images">
-<button id="bullets" arial-label="Bullets"><img src="images/bullets.png" alt="" class="img-bullets"></button><button id="more-1" aria-label="More" aria-labelledby="more-1 bullets">
-	<img src="images/down-arrow.png" alt="" class="img-more">
-</button><button id="text-align" arial-label="Text alignment">
-	<img src="images/text-align.png" alt="" class="img-text-align">
-</button><button id="more-2" aria-label="More" aria-labelledby="more-2 text-align">
-	<img src="images/down-arrow.png" alt="" class="img-more">
-</button>
-
-<style type="text/css">
-#inline-images button { 
-	padding: 0;
-	border: none;
-	background-color: transparent;
-}
-#inline-images img {
-	width: 30px;
-}
-#inline-images img.img-more {
-	width: 20px;
-}
-
-</style>
-</div>
-	</div>
-</div>
-		<h4>Stratégie 1 : Plusieurs instances de l’étiquette de texte « More »</h4>
-		<p>Avec cette stratégie, chaque instance du bouton « More » prend une valeur unique d’attribut <code>id</code>, ce qui donne des valeurs id « more-1 » et « more-2 ». L’attribut <code>aria-labelledby</code> enchaîne un nom en pointant les valeurs de l’attribut <code>id</code> lui-même et le bouton partenaire, ce qui donne les étiquettes « More Bullets » et « More Text alignment ».</p>
-		<p class="wb-inv">Code commence</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;button id="bullets" arial-label="Puces"&gt;
+			<div class="panel-body">
+				<h3 class="text-success mrgn-tp-0">
+					<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Nommer des images fonctionnelles à l’aide des attributs <code>aria-label</code> et <code>aria-labelled</code>
+				</h3>
+				<p>Dans cet exemple, chacun des deux boutons de formatage du texte est accompagné d’un bouton « More » (Lire la suite) identique. Les boutons de formatage sont nommés avec l’attribut <code>aria-label</code>. Les boutons « More » (Lire la suite) sont nommés avec l’attribut <code>aria-labelledby</code>, pointant vers les valeurs <code>id</code> des éléments contenant les fragments d’étiquette souhaités : « Lire la suite » + soit « Bullets » (Puces) soit « Text alignment » (Alignement du texte). L’attribut <code>alt</code> de chaque élément de bouton <code>&lt;img&gt;</code> est réglé sur null (vide) : <code>alt=””</code>.</p>
+						
+				<div class="panel panel-primary mrgn-tp-md">
+					<div class="panel-body mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
+						<div id="inline-images">
+							<button id="bullets" arial-label="Bullets"><img src="images/bullets.png" alt="" class="img-bullets"></button><button id="more-1" aria-label="More" aria-labelledby="more-1 bullets">
+								<img src="images/down-arrow.png" alt="" class="img-more">
+							</button><button id="text-align" arial-label="Text alignment">
+								<img src="images/text-align.png" alt="" class="img-text-align">
+							</button><button id="more-2" aria-label="More" aria-labelledby="more-2 text-align">
+								<img src="images/down-arrow.png" alt="" class="img-more">
+							</button>
+							
+							<style type="text/css">
+							#inline-images button { 
+								padding: 0;
+								border: none;
+								background-color: transparent;
+							}
+							#inline-images img {
+								width: 30px;
+							}
+							#inline-images img.img-more {
+								width: 20px;
+							}
+							
+							</style>
+						</div>
+						<p class="wb-inv">Fin de l'exemple</p>	
+					</div>
+				</div>
+				<h4>Stratégie 1 : Plusieurs instances de l’étiquette de texte « More »</h4>
+				<p>Avec cette stratégie, chaque instance du bouton « More » prend une valeur unique d’attribut <code>id</code>, ce qui donne des valeurs id « more-1 » et « more-2 ». L’attribut <code>aria-labelledby</code> enchaîne un nom en pointant les valeurs de l’attribut <code>id</code> lui-même et le bouton partenaire, ce qui donne les étiquettes « More Bullets » et « More Text alignment ».</p>
+				<p class="wb-inv">Code commence</p>
+<pre><code class="language-html">&lt;button id="bullets" arial-label="Puces"&gt;
 	&lt;img src="images/bullets.png" alt=""&gt;
 &lt;/button&gt;
 &lt;button id="more-1" aria-label="Lire la suite" aria-labelledby="more-1 bullets&gt;
@@ -275,19 +268,17 @@
 &lt;/button&gt;
 &lt;button id="more-2" aria-label="Lire la suite" aria-labelledby="more-2 text-align"&gt;
 	&lt;img src="images/down-arrow.png" alt=""&gt;
-&lt;/button&gt;</code>
-</pre>
-		</div>
-		<p class="wb-inv">Fins du code</p>
+&lt;/button&gt;</code></pre>
 		
-		<h4>Stratégie : Une seule instance de l’étiquette de texte « More »</h4>
-		<p>Lorsqu’ils utilisent l’attribut <code>aria-labelledby</code>, les développeurs peuvent préférer cibler une valeur unique d’attribut <code>id</code> cible pour le nom d’une icône répétitive.</p>
-		<p>Cette stratégie permet d’attribuer une valeur d’attribut <code>id</code> à une instance définissant le texte « More » et de régler l’affichage des feuilles de style en cascades à « aucun ». L’attribut <code>aria-labelledby</code> (et <code>aria-descripbedby</code>) peut cibler un élément <code>dont l’affichage</code> est établi à « aucun ». L’attribut <code>aria-labelledby</code> concatène un nom en pointant les valeurs d’attribut id de l’instance qui définit et le bouton partenaire, ce qui donne les étiquettes « More Bullets » et « More Text alignment ».</p>
-		<p>Contrairement à la première stratégie, les boutons « More » n’ont pas besoin d’attributs <code>id</code> ou <code>aria-label</code>, car ils ne contribuent pas à l’étiquette concaténée.</p>
-		<p class="wb-inv">Code commence</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;span id="more" style="display:none"&gt;Lire la suite&lt;/span&gt;
+				<p class="wb-inv">Fins du code</p>
+				
+				<h4>Stratégie : Une seule instance de l’étiquette de texte « More »</h4>
+				<p>Lorsqu’ils utilisent l’attribut <code>aria-labelledby</code>, les développeurs peuvent préférer cibler une valeur unique d’attribut <code>id</code> cible pour le nom d’une icône répétitive.</p>
+				<p>Cette stratégie permet d’attribuer une valeur d’attribut <code>id</code> à une instance définissant le texte « More » et de régler l’affichage des feuilles de style en cascades à « aucun ». L’attribut <code>aria-labelledby</code> (et <code>aria-descripbedby</code>) peut cibler un élément <code>dont l’affichage</code> est établi à « aucun ». L’attribut <code>aria-labelledby</code> concatène un nom en pointant les valeurs d’attribut id de l’instance qui définit et le bouton partenaire, ce qui donne les étiquettes « More Bullets » et « More Text alignment ».</p>
+				<p>Contrairement à la première stratégie, les boutons « More » n’ont pas besoin d’attributs <code>id</code> ou <code>aria-label</code>, car ils ne contribuent pas à l’étiquette concaténée.</p>
+				<p class="wb-inv">Code commence</p>
+
+<pre><code class="language-html">&lt;span id="more" style="display:none"&gt;Lire la suite&lt;/span&gt;
 
 &lt;button id="bullets" arial-label="Puces"&gt;
 	&lt;img src="icons/bullets.png" alt=""&gt;
@@ -302,8 +293,7 @@
 	&lt;img src="icons/down-arrow.png" alt=""&gt;
 &lt;/button&gt;</code>
 </pre>
-		</div>
-		<p class="wb-inv">Fins du code</p>
+				<p class="wb-inv">Fins du code</p>
 
 			</div>
 		</div>

--- a/learning/esdc-self-paced-web-accessibility-course/module5/functional-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/functional-images.html
@@ -91,9 +91,11 @@
 					<h3 class="text-success mrgn-tp-0">
 			<span class="glyphicon glyphicon-ok-circle"></span> Good example: Linked image</h3>
 		<p>In the example below, the Canada.ca logo in the banner links to the Canada.ca homepage. The <code>&lt;img&gt;</code> element is nested in the link. The alt text “Government of Canada home page” provides the link text.</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<img src="images/image1f.png" class="img-responsive" alt="Government of Canada home page">
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		<p class="wb-inv">Code begins</p>
@@ -110,22 +112,23 @@
 					<h3 class="text-success mrgn-tp-0">
 			<span class="glyphicon glyphicon-ok-circle"></span> Good example: Icon with meaningful alt text nested in link text</h3>
 		<p>In this example, an icon with the meaningful alt text “Opens in new window” is nested inside the link along with the link text “W3C Homepage”.  Screen reader users experience the link as “W3C homepage, opens in new window.”</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<a href="https://www.w3.org/" target="_blank">W3C Homepage 
 					<img src="images/image1d.png" class="" alt="Opens in new window">
 				</a>
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		<p class="wb-inv">Code begins</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;a href="https://www.w3.org/" target="_blank"&gt; 
+	
+<pre><code class="language-html">&lt;a href="https://www.w3.org/" target="_blank"&gt; 
 	W3C Homepage 
 	&lt;img src="new-window.png" alt="Opens in new window"&gt;
 &lt;/a&gt;</code>
 </pre>
-		</div>
+
 		<p class="wb-inv">Code ends</p>
 		<p>Note: This technique is often used with icons to indicate different file formats such as AVI, ODF, MP3, PDF, Word, etc. In that case, the text alternative should convey the format represented by each icon.</p>
 				</div>
@@ -135,19 +138,19 @@
 					<h3 class="text-success mrgn-tp-0">
 			<span class="glyphicon glyphicon-ok-circle"></span> Good example: Functional icon</h3>
 		<p>In this example, a clickable icon representing a printer denotes print functionality. Its text alternative is “Print this page”, rather than the literal “Printer”, because the purpose is to activate the print dialog.</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<img src="images/image22.png" class="img-responsive" alt="Print this page">
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		<p class="wb-inv">Code begins</p>
-		<div style="padding-top: 1em">
-<pre>
-<code class="language-html">&lt;a href="javascript:print()"&gt;
+		
+<pre><code class="language-html">&lt;a href="javascript:print()"&gt;
 	&lt;img src="print.png" alt="Print this page"&gt;
 &lt;/a&gt;</code>
 </pre>
-		</div>
 		<p class="wb-inv">Code ends</p>
 				</div>
 		</div>
@@ -157,11 +160,13 @@
 			<span class="glyphicon glyphicon-ok-circle"></span> Good example: Image used in a button
 		</h3>
 		<p>The following image is used to give the button a distinct style. In this case, it is the button to initiate a search request and the nested icon is a magnifying lens. The text alternative for the image is “search” to convey the purpose of the button, rather than the literal “magnifying lens”.</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<label for="search">Search</label>
 				<input type="search" name="search"></input>
 				<input type="image" src="images/searchbutton.png" alt="Search" style="width: 1.5em">
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		
@@ -179,12 +184,14 @@
 					<h3 class="text-success mrgn-tp-0">
 			<span class="glyphicon glyphicon-ok-circle"></span> Good example: Redundant image within link text</h3>
 		<p>In this example, the Company XYZ logo accompanies a text link that leads to the Company XYZ home page. The image does not represent different functionality or convey other information than that already provided in the link text. In effect the image is a simple visual assist to the link text. A null (empty) alt value is applied, (<code>alt=""</code>), to avoid redundancy and repetition.</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<a href="https://www.CompanyXYZ.ca/">
 					<img src="images/image2b.png" class="img-responsive" alt="">
 					Company XYZ home page
 				</a>
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		<p class="wb-inv">Code begins</p>
@@ -229,8 +236,9 @@
 					<h3 class="text-success mrgn-tp-0">
 			<span class="glyphicon glyphicon-ok-circle"></span> Good example: Naming functional images using the <code>aria-label</code> and <code>aria-labelledby</code> attributes</h3>
 		<p>In this example, two text-styling buttons are each accompanied by an identical “more” details button. The styling buttons are named with the <code>aria-label</code> attribute. The “more” buttons are named with the <code>aria-labelledby</code> attribute, pointing to the <code>id</code> attribute values of the elements holding the desired label fragments: “More” + either “Bullets” or “Text alignment”. The <code>alt</code> attribute of each button <code>&lt;img&gt;</code> element is set to null (empty): <code>alt=""</code>.</p>
-	<div class="panel panel-primary">
-		<div class="panel-body mrgn-bttm-0">	
+	<div class="panel panel-primary mrgn-tp-md">
+		<div class="panel-body mrgn-bttm-0">
+			<p class="wb-inv">Example begins</p>	
 
 <div id="inline-images">
 <button id="bullets" arial-label="Bullets"><img src="images/bullets.png" alt="" class="img-bullets"></button><button id="more-1" aria-label="More" aria-labelledby="more-1 bullets">
@@ -256,6 +264,7 @@
 
 </style>
 </div>
+			<p class="wb-inv">Example ends</p>
 		</div>
 	</div>
 		

--- a/learning/esdc-self-paced-web-accessibility-course/module5/groups-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/groups-images-fr.html
@@ -95,8 +95,9 @@ j<!DOCTYPE html>
 			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple 1 : Groupe d’images représentant un élément d’information unique
 		</h2>
 		<p>Une norme de classement par nombre d’étoiles consiste en une image qui montre 5 étoiles, mais dont le texte de remplacement ne doit communiquer qu’un seul message, soit le nombre d’étoiles sur 5.</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 				<p>Rating:
 					<img src="images/star-full.png" alt="3,5&nbsp;étoiles sur 5">
 					<img src="images/star-full.png" alt="">
@@ -104,6 +105,7 @@ j<!DOCTYPE html>
 					<img src="images/star-half.png" alt="">
 					<img src="images/star-empty.png" alt="">		
 				</p>
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 		<p class="wb-inv">Code commence</p>
@@ -129,25 +131,27 @@ j<!DOCTYPE html>
 		<p>Une collection d’images peut être une galerie, auquel cas chaque image a besoin de son propre texte de remplacement, et le groupe lui-même a besoin d’un texte de remplacement.</p>
 		<p>Dans cet exemple, la <code>&lt;figure&gt;</code> contient l’élément <code>&lt;img&gt;</code>, et la <code>&lt;figcaption&gt;</code> fournit une légende pour chaque image d’une collection. L’élément <code>&lt;figure&gt;</code> peut être emboîté, le parent fournissant une légende pour toute la collection d’images.</p>
 		
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 
-		<figure>		
-			<figcaption>Les châteaux à travers les âges : 1423, 1756 et 1936</figcaption>
-			
-			<figure>
-				<img src="images/castle-etching.jpg" class="img-responsive" alt="The castle has one tower, and a tall wall around it.">
-				<figcaption>Charbon sur bois. Anonyme, vers 1423.</figcaption>
-			</figure>
-			<figure>
-				<img src="images/castle-painting.jpg" class="img-responsive" alt="The castle now has two towers and two walls.">
-				<figcaption>Peinture à base d’huile sur toile. Eloisa Faulkner, 1756.</figcaption>
-			</figure>
-			<figure>
-				<img src="images/castle-fluro.jpg" class="img-responsive" alt="The castle lies in ruins, the original tower all that remains in one piece.">
-				<figcaption>Photographie analogique. <span lang="fr">Séraphin Médéric Mieusement</span>, 1936.</figcaption>
-			</figure>
-		</figure>
+				<figure>		
+					<figcaption>Les châteaux à travers les âges : 1423, 1756 et 1936</figcaption>
+					
+					<figure>
+						<img src="images/castle-etching.jpg" class="img-responsive" alt="The castle has one tower, and a tall wall around it.">
+						<figcaption>Charbon sur bois. Anonyme, vers 1423.</figcaption>
+					</figure>
+					<figure>
+						<img src="images/castle-painting.jpg" class="img-responsive" alt="The castle now has two towers and two walls.">
+						<figcaption>Peinture à base d’huile sur toile. Eloisa Faulkner, 1756.</figcaption>
+					</figure>
+					<figure>
+						<img src="images/castle-fluro.jpg" class="img-responsive" alt="The castle lies in ruins, the original tower all that remains in one piece.">
+						<figcaption>Photographie analogique. <span lang="fr">Séraphin Médéric Mieusement</span>, 1936.</figcaption>
+					</figure>
+				</figure>
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 		

--- a/learning/esdc-self-paced-web-accessibility-course/module5/groups-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/groups-images.html
@@ -123,25 +123,26 @@
 		</h2>
 		<p>A collection of images may be a gallery, in which case each image needs its own alt text and the group itself needs alt text.</p>
 		<p>In this example, the <code>&lt;figure&gt;</code> holds the <code>&lt;img&gt;</code> element and the <code>&lt;figcaption&gt;</code> provides a caption for each image in a collection. The <code>&lt;figure&gt;</code> element can be nested, with the parent providing a caption for the entire collection of images.</p>
-		<div class="panel panel-primary">
-						<div class="panel-body well mrgn-bttm-0">
-
-		<figure>		
-			<figcaption>The castle through the ages: 1423, 1756, and 1936 respectively.</figcaption>
-			
-			<figure>
-				<img src="images/castle-etching.jpg" class="img-responsive" alt="The castle has one tower, and a tall wall around it.">
-				<figcaption>Charcoal on  wood. Anonymous, circa 1423.</figcaption>
-			</figure>
-			<figure>
-				<img src="images/castle-painting.jpg" class="img-responsive" alt="The castle now has two towers and two walls.">
-				<figcaption>Oil-based paint on canvas. Eloisa Faulkner, 1756.</figcaption>
-			</figure>
-			<figure>
-				<img src="images/castle-fluro.jpg" class="img-responsive" alt="The castle lies in ruins, the original tower all that remains in one piece.">
-				<figcaption>Film photograph. <span lang="fr">Séraphin Médéric Mieusement</span>, 1936.</figcaption>
-			</figure>
-		</figure>
+		<div class="panel panel-primary mrgn-tp-md">
+			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
+				<figure>		
+					<figcaption>The castle through the ages: 1423, 1756, and 1936 respectively.</figcaption>
+					
+					<figure>
+						<img src="images/castle-etching.jpg" class="img-responsive" alt="The castle has one tower, and a tall wall around it.">
+						<figcaption>Charcoal on  wood. Anonymous, circa 1423.</figcaption>
+					</figure>
+					<figure>
+						<img src="images/castle-painting.jpg" class="img-responsive" alt="The castle now has two towers and two walls.">
+						<figcaption>Oil-based paint on canvas. Eloisa Faulkner, 1756.</figcaption>
+					</figure>
+					<figure>
+						<img src="images/castle-fluro.jpg" class="img-responsive" alt="The castle lies in ruins, the original tower all that remains in one piece.">
+						<figcaption>Film photograph. <span lang="fr">Séraphin Médéric Mieusement</span>, 1936.</figcaption>
+					</figure>
+				</figure>
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		

--- a/learning/esdc-self-paced-web-accessibility-course/module5/image-maps-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/image-maps-fr.html
@@ -93,8 +93,9 @@
 				<h2 id="example" class="text-success mrgn-tp-0">
 					<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Images cliquables
 				</h2>
-				<div class="panel panel-primary">
+				<div class="panel panel-primary mrgn-tp-md">
 					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>
 						<p> Veuillez sélectionner une forme : 
 							<img src="images/shapes.png" usemap="#shapes" alt="FQuatre formes sont disponibles&nbsp;: une boîte creuse rouge, un cercle vert, un triangle bleu et une étoile jaune à quatre pointes."> 
 							<map name="shapes"> 
@@ -105,6 +106,7 @@
 								<area shape=poly coords="450,25,435,60,400,75,435,90,450,125,465,90,500,75,465,60" href="yellow.html" alt="Étoile jaune"> 
 							</map> 
 						</p>
+						<p class="wb-inv">Fin de l'exemple</p>	
 					</div>
 				</div>
 				

--- a/learning/esdc-self-paced-web-accessibility-course/module5/images-text-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/images-text-fr.html
@@ -90,8 +90,9 @@
 				<p>Dans cet exemple, on utilise du texte réel stylé avec des feuilles de style en cascades plutôt qu’une image de texte. Les propriétés CSS sont entièrement responsables du style, de l’espacement et de la mise en page des polices et du texte.</p>
 				<!-- <img src="images/image26.png" class="img-responsive" alt=""> -->
 		
-				<div class="panel panel-primary">
-					<div class="panel-body well mrgn-bttm-0">				
+				<div class="panel panel-primary mrgn-tp-md">
+					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">D&eacute;but de l'exemple</p>				
 						<p class="checker">L&apos;accessibilit&eacute; au bout de vos doigts<p/>
 						<style type="text/css">
 .checker {						
@@ -107,6 +108,7 @@
   color:white;
 }						
 						</style>
+						<p class="wb-inv">Fin de l'exemple</p>	
 					</div>
 				</div>
 				<div style="padding-top: 1em">
@@ -150,9 +152,11 @@
 		</ul>
 		<h4 class="">Stratégie 1 : Utiliser une image avec texte de remplacement décrivant l’expression mathématique</h4>
 		<p>Les images d’expressions mathématiques ne doivent être utilisées que lorsque les mathématiques font exception au contenu ordinaire du site Web. Dans ce cas, la valeur de l’attribut alt de l’élément &lt;img&gt; doit communiquer l’expression mathématique, sauf si plus de 150 caractères sont requis, auquel cas il faut utiliser une description longue. Dans l’exemple ci-dessous, l’image affiche un nombre décimal récurrent et le texte de remplacement est « zéro point un, récurrent »</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
-				<img src="images/image2e.png" class="img-responsive" alt=":zéro point un, récurrent">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
+				<img src="images/image2e.png" class="img-responsive" alt="zéro point un, récurrent">
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 		<p class="wb-inv">Code commence</p>
@@ -165,46 +169,48 @@
 		<p>Dans l’exemple ci-dessous, MathML communique une expression mathématique avec un balisage sémantique et une syntaxe adaptée aux technologies d’assistance comme les lecteurs d’écran. MathJax offre un bon rendu pour l’écran avec la composition appropriée.</p>
 		<!-- <img src="images/image2f.png" class="img-responsive" alt=""> -->
 		
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
-			   <math display="block" xmlns="http://www.w3.org/1998/Math/MathML">
-				  <mrow>
-					 <mi>E</mi><mo>=</mo>
-					 <mfrac>
-						<mrow>
-						   <mn>2</mn><mi>π</mi><mi>h</mi>
-						   <msup>
-							  <mi>c</mi>
-							  <mn>2</mn>
-						   </msup>
-						</mrow>
-						<mrow>
-						   <msup>
-							  <mi>λ</mi>
-							  <mn>5</mn>
-						   </msup>
-						   <mrow>
-							  <mo>(</mo>
-							  <mrow>
-								 <msup>
-									<mi>e</mi>
-									<mrow>              
-										<mi>h</mi><mi>c</mi><mo>−</mo><mi>λ</mi>
-										<msub>
-										   <mi>k</mi>
-										   <mi>b</mi>
-										</msub>
-										<mi>T</mi>
-									</mrow>
-								  </msup>                      
-								  <mo>−</mo><mn>1</mn>
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
+				   <math display="block" xmlns="http://www.w3.org/1998/Math/MathML">
+					  <mrow>
+						 <mi>E</mi><mo>=</mo>
+						 <mfrac>
+							<mrow>
+							   <mn>2</mn><mi>π</mi><mi>h</mi>
+							   <msup>
+								  <mi>c</mi>
+								  <mn>2</mn>
+							   </msup>
+							</mrow>
+							<mrow>
+							   <msup>
+								  <mi>λ</mi>
+								  <mn>5</mn>
+							   </msup>
+							   <mrow>
+								  <mo>(</mo>
+								  <mrow>
+									 <msup>
+										<mi>e</mi>
+										<mrow>              
+											<mi>h</mi><mi>c</mi><mo>−</mo><mi>λ</mi>
+											<msub>
+											   <mi>k</mi>
+											   <mi>b</mi>
+											</msub>
+											<mi>T</mi>
+										</mrow>
+									  </msup>                      
+									  <mo>−</mo><mn>1</mn>
+								   </mrow>
+								  <mo>)</mo>
 							   </mrow>
-							  <mo>)</mo>
-						   </mrow>
-						</mrow>
-					 </mfrac>
-				  </mrow>                                                   
-			   </math>		
+							</mrow>
+						 </mfrac>
+					  </mrow>                                                   
+				   </math>	
+				<p class="wb-inv">Fin de l'exemple</p>		
 			</div>
 		</div>
 		<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/images-text.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/images-text.html
@@ -89,8 +89,9 @@
 				<p>In this example, real text styled with CSS is used rather than an image of text. The CSS properties are solely responsible for font and text styling, spacing and layout.</p>
 				<!-- <img src="images/image26.png" class="img-responsive" alt=""> -->
 				
-				<div class="panel panel-primary">
-					<div class="panel-body well mrgn-bttm-0">				
+				<div class="panel panel-primary mrgn-tp-md">
+					<div class="panel-body well mrgn-bttm-0">
+						<p class="wb-inv">Example begins</p>				
 						<p class="checker">Accessibility at your fingertips</p>
 						<style type="text/css">
 .checker {						
@@ -106,6 +107,7 @@
   color:white;
 }						
 						</style>
+						<p class="wb-inv">Example ends</p>
 					</div>
 				</div>
 				<div style="padding-top: 1em">
@@ -150,9 +152,11 @@
 		</ul>
 		<h4 class="">Approach 1: Use an image with alt text describing the math expression</h4>
 		<p>Images of math expressions should only be used when math is an exception to the regular content of the website. In these cases, the &lt;img&gt; element’s alt attribute value should communicate the math expression, unless more than 150 characters is required, in which case a long description should be used.In the example below, the image displays a recurring decimal number and the alt text is “zero point one, recurring”</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<img src="images/image2e.png" class="img-responsive" alt="zero point one, recurring">
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		<p class="wb-inv">Code begins</p>
@@ -165,46 +169,48 @@
 		<p>In the example below, MathML communicates a math expression with semantic markup and proper syntax to assistive technologies like screen readers. MathJax renders it for the screen with the correct typesetting.</p>
 		<!-- <img src="images/image2f.png" class="img-responsive" alt=""> -->
 		
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body well mrgn-bttm-0">
-			   <math display="block" xmlns="http://www.w3.org/1998/Math/MathML">
-				  <mrow>
-					 <mi>E</mi><mo>=</mo>
-					 <mfrac>
-						<mrow>
-						   <mn>2</mn><mi>π</mi><mi>h</mi>
-						   <msup>
-							  <mi>c</mi>
-							  <mn>2</mn>
-						   </msup>
-						</mrow>
-						<mrow>
-						   <msup>
-							  <mi>λ</mi>
-							  <mn>5</mn>
-						   </msup>
-						   <mrow>
-							  <mo>(</mo>
-							  <mrow>
-								 <msup>
-									<mi>e</mi>
-									<mrow>              
-										<mi>h</mi><mi>c</mi><mo>−</mo><mi>λ</mi>
-										<msub>
-										   <mi>k</mi>
-										   <mi>b</mi>
-										</msub>
-										<mi>T</mi>
-									</mrow>
-								  </msup>                      
-								  <mo>−</mo><mn>1</mn>
+				<p class="wb-inv">Example begins</p>
+				   <math display="block" xmlns="http://www.w3.org/1998/Math/MathML">
+					  <mrow>
+						 <mi>E</mi><mo>=</mo>
+						 <mfrac>
+							<mrow>
+							   <mn>2</mn><mi>π</mi><mi>h</mi>
+							   <msup>
+								  <mi>c</mi>
+								  <mn>2</mn>
+							   </msup>
+							</mrow>
+							<mrow>
+							   <msup>
+								  <mi>λ</mi>
+								  <mn>5</mn>
+							   </msup>
+							   <mrow>
+								  <mo>(</mo>
+								  <mrow>
+									 <msup>
+										<mi>e</mi>
+										<mrow>              
+											<mi>h</mi><mi>c</mi><mo>−</mo><mi>λ</mi>
+											<msub>
+											   <mi>k</mi>
+											   <mi>b</mi>
+											</msub>
+											<mi>T</mi>
+										</mrow>
+									  </msup>                      
+									  <mo>−</mo><mn>1</mn>
+								   </mrow>
+								  <mo>)</mo>
 							   </mrow>
-							  <mo>)</mo>
-						   </mrow>
-						</mrow>
-					 </mfrac>
-				  </mrow>                                                   
-			   </math>		
+							</mrow>
+						 </mfrac>
+					  </mrow>                                                   
+				   </math>	
+				<p class="wb-inv">Example ends</p>	
 			</div>
 		</div>
 		<details class="mrgn-tp-lg">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/informative-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/informative-images-fr.html
@@ -96,12 +96,14 @@
 			<span class="glyphicon glyphicon-ok-circle"></span> Bon exemple : Images utilisées pour compléter d’autres renseignements</h2>
 			<p>L’image suivante montre un chien portant une clochette. Elle complète le texte adjacent qui explique le rôle de cette clochette. Un court équivalent textuel suffit pour décrire l’information qui est affichée visuellement, mais qui n’est pas expliquée dans le texte; dans ce cas, l’équivalent textuel est « Chien avec une clochette attachée à son collier ».</p>
 			<p> <strong>Remarque :</strong> Si le texte comprenait une explication de la façon dont le chien porte la clochette (à son collier), l’image pourrait être considérée comme redondante et donc décorative. Comme ce n’est pas mentionné dans le texte, l’image est considérée comme informative.</p>
-			<div class="panel panel-primary">
+			<div class="panel panel-primary mrgn-tp-md">
 				<div class="panel-body well mrgn-bttm-0">
-			<figure>
-				<img style="float:left" src="images/dog.png" class="mrgn-rght-md" alt="Dog with a bell attached to its collar"/>
-				<figcaption>Les chiens-guides qui ne sont pas en service portent souvent une clochette dont le bruit aide le propriétaire aveugle à repérer l’emplacement du chien.</figcaption>
-			</figure>
+					<p class="wb-inv">D&eacute;but de l'exemple</p>
+					<figure>
+						<img style="float:left" src="images/dog.png" class="mrgn-rght-md" alt="Dog with a bell attached to its collar"/>
+						<figcaption>Les chiens-guides qui ne sont pas en service portent souvent une clochette dont le bruit aide le propriétaire aveugle à repérer l’emplacement du chien.</figcaption>
+					</figure>
+					<p class="wb-inv">Fin de l'exemple</p>	
 				</div>
 			</div>
 			<p class="wb-inv">Code commence</p>

--- a/learning/esdc-self-paced-web-accessibility-course/module5/informative-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/informative-images.html
@@ -95,12 +95,14 @@
 			<p>The following image shows a dog wearing a bell. It supplements the adjacent text that explains the purpose of this bell. A short text alternative is sufficient to describe the information that is displayed visually but is not explained in the text; in this case, the text alternative is “Dog with a bell attached to its collar”.</p>
 			<p> <strong>Note:</strong> If the text included an explanation of how the dog wears a bell, the image might be considered redundant and therefore decorative. As this isn’t mentioned in the text, the image is deemed to be informative.</p>
 			
-			<div class="panel panel-primary">
+			<div class="panel panel-primary mrgn-tp-md">
 				<div class="panel-body well mrgn-bttm-0">
-			<figure>
-				<img style="float:left" src="images/dog.png" class="mrgn-rght-md" alt="Dog with a bell attached to its collar"/>
-				<figcaption>Off-duty guide dogs often wear a bell. Its ring helps the blind owner keep track of the dog's location.</figcaption>
-			</figure>
+					<p class="wb-inv">Example begins</p>
+					<figure>
+						<img style="float:left" src="images/dog.png" class="mrgn-rght-md" alt="Dog with a bell attached to its collar"/>
+						<figcaption>Off-duty guide dogs often wear a bell. Its ring helps the blind owner keep track of the dog's location.</figcaption>
+					</figure>
+					<p class="wb-inv">Example ends</p>
 				</div>
 			</div>
 			<p class="wb-inv">Code begins</p>

--- a/learning/esdc-self-paced-web-accessibility-course/module5/svg-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/svg-images-fr.html
@@ -93,8 +93,9 @@
 			<li>Les SVG prennent en charge le balisage et les caractéristiques d’accessibilité.</li>
 		</ul>
 		<p>Cette image illustre la différence entre les images bitmap et les images vectorielles. L’image bitmap, appelée image tramée, est composée d’un ensemble fixe de pixels, tandis que l’image vectorielle est composée d’un ensemble fixe de formes. Dans cette image, la mise à l’échelle de l’image bitmap révèle les pixels tandis que la mise à l’échelle de l’image vectorielle préserve les formes :</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 				<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 915 585" role="image" aria-labelledby="svg-title">
 					<title id="svg-title">Illustration de la différence entre les images bitmap et vectorielles. La mise à l’échelle de l’image bitmap révèle des pixels tandis que la mise à l’échelle de l’image vectorielle préserve les formes.</title>
 					<defs>
@@ -136,6 +137,7 @@
 					<use xlink:href="#VectorLarge" transform="matrix(.17 0 0 .17 392 313)"/>
 					<use xlink:href="#RasterLarge" transform="matrix(.173 0 0 .173 -8.25 314)" height="100%" width="100%" y="0" x="0"/>
 				</svg>
+				<p class="wb-inv">Fin de l'exemple</p>	
 				<hr/>
 				<p class="small">Contributeurs de Wikipédia. (4 novembre 2021) Graphiques vectoriels adaptables. Wikipédia. Récupéré le 17 novembre 2021 sur le site <a href="https://en.wikipedia.org/wiki/Scalable_Vector_Graphics">https://en.wikipedia.org/wiki/Scalable_Vector_Graphics</a></p>
 			</div>
@@ -161,11 +163,13 @@
 			<li>Utiliser l’attribut <code>alt</code> pour fournir du texte de remplacement (préférable).</li>
 			<li>Peut également utiliser une étiquette <code>aria-label</code> ou <code>aria-labelledby</code> pour fournir du texte de remplacement.</li>
 		</ul>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 				<p>
 					<img src="images/Canada_Stop_sign.svg" class="img-responsive" alt="Stop sign" style="width:200px">
 				</p>
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 		<p class="wb-inv">Code commence</p>
@@ -198,13 +202,15 @@
 				</ul>
 			</li>
 		</ul>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 				<svg role="img" aria-labelledby="uniqueTitleID uniqueDescID" xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 200 200">
 					<title id="uniqueTitleID">carré rouge</title>
 					<desc id="uniqueDescID">Image SVG d’un carré rouge avec bordure noire</desc>
 					<path fill="red" stroke="#000" stroke-width="2.5" d="M168 168H32V32h136z"/>
 				</svg>
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 
@@ -257,8 +263,9 @@
 			</li>
 		</ul>
 		
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">D&eacute;but de l'exemple</p>
 		<!-- <img src="images/image30.png" class="img-responsive" alt=""> -->
 		
 				<svg width="200" height="100" role="img" aria-labelledby="uniqueTitleID2 uniqueTextID2">
@@ -266,6 +273,7 @@
 					<rect x="0" y="0" width="200" height="100" stroke="red" stroke-width="3px" fill="white"/>  
 					<text id="uniqueTextID2" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">Bonjour le monde!</text>     
 				</svg>
+				<p class="wb-inv">Fin de l'exemple</p>	
 			</div>
 		</div>
 <p class="wb-inv">Code commence</p>

--- a/learning/esdc-self-paced-web-accessibility-course/module5/svg-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/svg-images.html
@@ -92,8 +92,9 @@
 		</ul>
 
 		<p>This image illustrates the difference between bitmap and vector images. The bitmap image, called a Raster image, is composed of a fixed set of pixels, while the vector image is composed of a fixed set of shapes. In this image, scaling the bitmap reveals the pixels while scaling the vector image preserves the shapes:</p>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 915 585" role="image" aria-labelledby="svg-title">
 					<title id="svg-title">Illustration of the difference between bitmap and vector images. Scaling the bitmap image reveals pixels while scaling the vector image preserves the shapes</title>
 					<defs>
@@ -135,7 +136,7 @@
 					<use xlink:href="#VectorLarge" transform="matrix(.17 0 0 .17 392 313)"/>
 					<use xlink:href="#RasterLarge" transform="matrix(.173 0 0 .173 -8.25 314)" height="100%" width="100%" y="0" x="0"/>
 				</svg>
-				
+				<p class="wb-inv">Example ends</p>				
 				<hr/>
 				<p class="small">Wikipedia contributors. (2021, November 4). Scalable Vector Graphics. Wikipedia. Retrieved November 17, 2021, from <a href="https://en.wikipedia.org/wiki/Scalable_Vector_Graphics">https://en.wikipedia.org/wiki/Scalable_Vector_Graphics</a></p>
 			</div>
@@ -161,11 +162,13 @@
 			<li>Use the <code>alt</code> attribute to provide alt text (preferred)</li>
 			<li>Can also use <code>aria-label</code> or <code>aria-labelledby</code>attribute to provide alt text </li>
 		</ul>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<p>
 					<img src="images/Canada_Stop_sign.svg" class="img-responsive" alt="Stop sign" style="width:200px">
 				</p>
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		<p class="wb-inv">Code begins</p>
@@ -198,13 +201,15 @@
 				</ul>
 			</li>
 		</ul>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<svg role="img" aria-labelledby="uniqueTitleID uniqueDescID" xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 200 200">
 					<title id="uniqueTitleID">Red square</title>
 					<desc id="uniqueDescID">SVG image of a red square with a black border</desc>
 					<path fill="red" stroke="#000" stroke-width="2.5" d="M168 168H32V32h136z"/>
 				</svg>
+				<p class="wb-inv">Example ends</p>
 			</div>
 		</div>
 		
@@ -254,14 +259,15 @@
 				</ul>
 			</li>
 		</ul>
-		<div class="panel panel-primary">
+		<div class="panel panel-primary mrgn-tp-md">
 			<div class="panel-body mrgn-bttm-0">
+				<p class="wb-inv">Example begins</p>
 				<svg width="200" height="100" role="img" aria-labelledby="uniqueTitleID2 uniqueTextID2">
 					<title id="uniqueTitleID2">A rectangle with red border with text inside</title>  
 					<rect x="0" y="0" width="200" height="100" stroke="red" stroke-width="3px" fill="white"/>  
 					<text id="uniqueTextID2" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">Hello World!</text>     
 				</svg>
-			</div>
+				<p class="wb-inv">Example ends</p>
 		</div>
 
 		<p class="wb-inv">Code begins</p>


### PR DESCRIPTION
Created more uniform class names for div holding examples. 
Added "Example starts"/"Example ends" in En and Fr to modules 1-5