### PR TITLE
fixes for mod 10

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/module10/keyboard-input.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/keyboard-input.html
@@ -251,11 +251,10 @@
 						<p>In this example, a custom image link responds to mouse click only and can’t be activated by keyboard. It lacks an equivalent event handler for the Enter key. The <code>onclick</code> event only responds to keyboard input when applied to a native HTML button or link, and this is an <code>&lt;img&gt;</code> element. </p>
 						<p>The image link also lacks a <code>tabindex="0"</code> attribute so doesn’t receive keyboard focus.</p>
 						<p>Finally, the image link lacks the <code>role="link"</code> attribute, which identifies it to assistive technology as a link.</p>
-						<p><mark>TODO: Fix this linked image. Provide a real URL.</mark></p>
 						<div class="panel panel-primary mrgn-tp-md">
 							<div class="panel-body mrgn-bttm-0">
 								
-								<img src="images/image1.png" class="img-link img-responsive" alt="Go to next page" onclick="window.location.href='http://www.example.com/page5.html'">
+								<img src="images/image1.png" class="img-link img-responsive" alt="Go to next page" onclick="window.location.href='index.html'">
 								<style type="text/css">
 									.img-link:hover { cursor: pointer;  }
 								</style>
@@ -263,7 +262,7 @@
 							</div>
 						</div>
 						<p class="wb-inv">Code begins</p>
-<pre><code class="language-html">&lt;img class="img-link" onclick="goToLink(event, 'http://www.example.com/page5.html')" src="arrow.gif" alt="Go to next page"&gt;</code></pre>
+<pre><code class="language-html">&lt;img class="img-link" onclick="goToLink(event, 'index.html')" src="arrow.gif" alt="Go to next page"&gt;</code></pre>
 						<p class="wb-inv">Code ends</p>
 						<p class="wb-inv">Code begins</p>
 <pre><code class="language-css">.img-link:hover { 
@@ -547,11 +546,17 @@ function onNewPage() {
 								<!-- Trigger/Open The Modal -->
 								<button class="submit" id="myBtn">Submit</button>
 								<!-- The Modal -->
-								<div id="myModal" class="modal">
+								<div id="myModal" class="modal" role="dialog"
+     aria-labelledby="dialog"
+     aria-describedby="popup dialog">
 									<!-- Modal content -->
 									<div class="modal-content">
-										<h2>Your form has been submitted.</h2>
-										<button class="btn-close">Close</button>
+									<header class="modal-header">
+										<h2 class="modal-title">Your form has been submitted.</h2>
+									</header>
+										<div class="modal-body">
+											<button class="btn-close">Close</button>
+									</div>
 									</div>
 								</div>
 								<script>
@@ -564,18 +569,28 @@ function onNewPage() {
 									// When the user clicks the button, open the modal 
 									btnSubmit.onclick = function() {
 									   modal.style.display = "block";
+									   btnClose.focus();
 									}
 									// When the user clicks the close button, close the modal
 									btnClose.onclick = function() {	  
 									   modal.style.display = "none";
+									   btnSubmit.focus();
 									}
 									// When the user clicks anywhere outside of the modal, close it
 									window.onclick = function(event) {
 									   if (event.target == modal) {
 										  modal.style.display = "none";
+										  btnSubmit.focus();
 									   }
-									}								
-								</script>
+									}	
+
+									document.addEventListener('keyup', function (event) {
+									  if ( event.keyCode == 27 )   {
+										  modal.style.display = "none";
+										  btnSubmit.focus();
+									  }
+									})									
+																	</script>
 								<style type="text/css">
 									/* The Modal (background) */
 									.modal {
@@ -689,17 +704,27 @@ var btnClose = document.getElementsByClassName("btn-close")[0];
 // When the user clicks the button, open the modal 
 btnSubmit.onclick = function() {
    modal.style.display = "block";
+   btnClose.focus();
 }
 // When the user clicks the close button, close the modal
-btnClose.onclick = function() {     
+btnClose.onclick = function() {	  
    modal.style.display = "none";
+   btnSubmit.focus();
 }
 // When the user clicks anywhere outside of the modal, close it
 window.onclick = function(event) {
    if (event.target == modal) {
-     modal.style.display = "none";
+	  modal.style.display = "none";
+	  btnSubmit.focus();
    }
-}</code></pre>
+}	
+
+document.addEventListener('keyup', function (event) {
+  if ( event.keyCode == 27 )   {
+	  modal.style.display = "none";
+	  btnSubmit.focus();
+  }
+})	</code></pre>
 							<p class="wb-inv">Code ends</p>
 						</details>
 					</div>


### PR DESCRIPTION
Fixed the following:
Bad example: Mouse-dependent link
•	Aneta: Fix a linked image and provide a real URL for destination (a course page?).
Good example: Focus managed on a dialog using keyboard interaction
•	Aneta: Implement the full dialog (modal) pattern: role and aria-labelledby, close on ESC key, focus constrained to foreground window. Move focus to close button after triggering modal)
