### PR TITLE
fixed broken skip links for document auditor index pages

### DIFF
--- a/learning/document-auditor-learning-path/index-fr.html
+++ b/learning/document-auditor-learning-path/index-fr.html
@@ -58,7 +58,7 @@
       <div class="row wb-eqht">
         <!-- CRA Accessibility Learning Paths Start -->
         <div class="col-md-12">
-          <h1>
+          <h1 property="name" id="wb-cont">
             Parcours d’apprentissage pour les vérificateurs de l’accessibilité
             des documents
           </h1>

--- a/learning/document-auditor-learning-path/index.html
+++ b/learning/document-auditor-learning-path/index.html
@@ -58,7 +58,9 @@
       <div class="row wb-eqht">
         <!-- CRA Accessibility Learning Paths Start -->
         <div class="col-md-12">
-          <h1>Learning Path for Document Accessibility Auditors</h1>
+          <h1 property="name" id="wb-cont">
+            Learning Path for Document Accessibility Auditors
+          </h1>
 
           <!-- Learning Path 1 -->
           <h2>Document Accessibility Auditors</h2>


### PR DESCRIPTION
Added the correct property and id value to the H1 on the index pages to fix the skip link.