### PR TITLE
updated titles on document auditor index pages to match h1's

### DIFF
--- a/learning/document-auditor-learning-path/index-fr.html
+++ b/learning/document-auditor-learning-path/index-fr.html
@@ -6,7 +6,7 @@
   <head>
     <meta charset="utf-8" />
     <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-    <title>Apprentissage - EDSC / Bureau de l'accessibilité des TI</title>
+    <title>Parcours d'apprentissage pour les vérificateurs de l'accessibilité des documents - EDSC / Bureau de l'accessibilité des TI</title>
     <meta content="width=device-width,initial-scale=1" name="viewport" />
     <!-- Meta data -->
     <meta

--- a/learning/document-auditor-learning-path/index.html
+++ b/learning/document-auditor-learning-path/index.html
@@ -6,7 +6,7 @@
   <head>
     <meta charset="utf-8" />
     <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-    <title>Learning - ESDC / IT Accessibility office</title>
+    <title>Learning Path for Document Accessibility Auditors - ESDC / IT Accessibility office</title>
     <meta content="width=device-width,initial-scale=1" name="viewport" />
     <!-- Meta data -->
     <meta


### PR DESCRIPTION
Updated the titles on the document auditor index pages to match the h1 elements and provide a more detailed description.