### PR TITLE
Official wcag 2.1 SC translations

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/module10/introduction-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/introduction-fr.html
@@ -82,30 +82,30 @@
 				<h2 id="resources1" class="wb-inv">Ressources WCAG connexes</h2>
 				<details class="mrgn-tp-lg">
 					<summary class="bg-info">Ressources WCAG connexes</summary>
-                        <p class="mrgn-tp-md">En anglais seulement.</p>
+
 					<h3>Critères de succès</h3>
 					<ul>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus" lang="en-CA">1.4.13: Content on Hover or Focus</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus" hreflang="en">1.4.13 : Contenu au survol ou au focus (en anglais)</a>
 						</li>
 
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard" lang="en-CA">2.1.1: Keyboard</a>
+							<a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/keyboard-operation-keyboard-operable.html">2.1.1 : Clavier</a>
 						</li>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap" lang="en-CA">2.1.2: No Keyboard Trap</a>
+							<a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/keyboard-operation-trapping.html">2.1.2 : Pas de pi&#232;ge au clavier</a>
 						</li>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures" lang="en-CA">2.5.1: Pointer Gestures</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures" hreflang="en">2.5.1 : Gestes de commande du curseur (en anglais)</a>
 						</li>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation" lang="en-CA">2.5.2: Pointer Cancellation</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation" hreflang="en">2.5.2 : Annulation du curseur (en anglais)</a>
 						</li>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation" lang="en-CA">2.5.4: Motion Actuation</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation" hreflang="en">2.5.4 : Activation par le mouvement (en anglais)</a>
 						</li>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/target-size" lang="en-CA">2.5.5: Target Size</a> (Niveau AAA)
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/target-size" hreflang="en">2.5.5 : Taille de la cible (en anglais)</a> (Niveau AAA)
 						</li>
 					</ul>
 				</details>

--- a/learning/esdc-self-paced-web-accessibility-course/module10/motion-actuation-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/motion-actuation-fr.html
@@ -76,7 +76,7 @@
 			<h3 id="motion-actuation-success-criteria">Critères de succès</h3>
 			<ul>
 				<li>
-					<a href="https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation" hreflang="en-CA" data-code="2.5.4">2.5.4 : Commande par le mouvement (en anglais)</a>
+					<a href="https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation" hreflang="en-CA" data-code="2.5.4">2.5.4 : Activation par le mouvement (en anglais)</a>
 				</li>
 			</ul>
 			<h3 id="motion-actuation-techniques">Techniques</h3>

--- a/learning/esdc-self-paced-web-accessibility-course/module10/mouse-input-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/mouse-input-fr.html
@@ -288,10 +288,10 @@ if ((e.keyCode || e.which) === 27)
 					<h3>Critères de succès</h3>
 					<ul>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus" hreflang="en-CA" data-code="1.4.13">1.4.13 : Contenu sur survol ou cible  (en anglais)</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus" hreflang="en-CA" data-code="1.4.13">1.4.13 : Contenu au survol ou au focus  (en anglais)</a>
 						</li>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation" hreflang="en-CA" data-code="2.5.2">2.5.2 : Annulation du curseur (en anglais)</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation" hreflang="en-CA" data-code="2.5.2">2.5.2 : Annulation de l’action du pointeur (en anglais)</a>
 						</li>
 					</ul>
 					<h3>Techniques</h3>

--- a/learning/esdc-self-paced-web-accessibility-course/module10/touch-input-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/touch-input-fr.html
@@ -137,7 +137,7 @@
 					<h3>Critères de succès</h3>
 					<ul>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures" hreflang="en-CA" data-code="2.5.1">2.5.1 : Gestes de commande du curseur (en anglais)</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures" hreflang="en-CA" data-code="2.5.1">2.5.1 : Gestes pour le contrôle du pointeur (en anglais)</a>
 						</li>
 						<li>
 							<a href="https://www.w3.org/WAI/WCAG21/Understanding/target-size" hreflang="en-CA" data-code="2.5.5">2.5.5 : Taille de la cible (en anglais)</a> (Niveau AAA)</li>

--- a/learning/esdc-self-paced-web-accessibility-course/module3/navigation-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/navigation-fr.html
@@ -761,7 +761,7 @@ F85&nbsp;: Échec du critère de succès 2.4.3 consistant à utiliser des menus 
 					<h4>Critères de succès</h4>
 					<ul>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts">2.1.4 : Raccourcis clavier de caract&#232;res (en anglais)</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts">2.1.4 : Raccourcis clavier utilisant des caractères (en anglais)</a>
 						</li>
 					</ul>
 					<h4 id="idelem4x10140">Techniques</h4>

--- a/learning/esdc-self-paced-web-accessibility-course/module6/forms-concepts-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/forms-concepts-fr.html
@@ -114,7 +114,7 @@
 								<a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/content-structure-separation-programmatic.html" data-code="1.3.1">1.3.1 : Information et relations</a>
 							</li>
 							<li>
-								<a href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose" hreflang="en-CA" data-code="1.3.5">1.3.5 : Déterminer le but de la saisie  (en anglais)</a>
+								<a href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose" hreflang="en-CA" data-code="1.3.5">1.3.5 : Identifier la finalité de la saisie  (en anglais)</a>
 							</li>
 							<li>
 								<a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/keyboard-operation-keyboard-operable.html" data-code="2.1.1">2.1.1 : Clavier</a>

--- a/learning/esdc-self-paced-web-accessibility-course/module7/colour-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/colour-fr.html
@@ -697,7 +697,7 @@
 												 <li>
 													<a lang="en" href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/visual-audio-contrast-contrast.html" data-code="1.4.3">1.4.3 : Contraste (Minimum)</a> </li>
 												 <li>
-													<a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast" data-code="1.4.11">1.4.11 : Contraste non textuel  (en anglais)</a> </li>
+													<a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast" data-code="1.4.11">1.4.11 : Contraste du contenu non textuel  (en anglais)</a> </li>
 						 <li>
 													<a lang="en" href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/content-structure-separation-understanding.html" data-code="1.3.3">1.3.3 : Caractéristiques sensorielles</a>
 												</li>

--- a/learning/esdc-self-paced-web-accessibility-course/module7/contrast-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/contrast-fr.html
@@ -184,7 +184,7 @@
                      <div class="panel panel-success mrgn-tp-lg">
                         <div class="panel-body">
                            <h2 class="text-success mrgn-tp-0 h3" id="sufficient-contrast"><span class="glyphicon glyphicon-ok-circle"></span>&nbsp;  Bon exemple : Contraste suffisant (contrôle)</h2>
-                           <p>La bordure grise de la saisie (#93958A) a un rapport de contraste de 3:1, qui satisfait tout juste au critère de succès des WCAG <a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast" lang="en-CA">1.4.11: Non-text Contrast</a> (en anglais seulement)</p>
+                           <p>La bordure grise de la saisie (#93958A) a un rapport de contraste de 3:1, qui satisfait tout juste au critère de succès des WCAG <a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast" lang="en-CA">1.4.11 : Contraste du contenu non textuel (en anglais)</a></p>
                            <div class="panel panel-primary">
 								<div class="panel-body mrgn-bttm-0">
 									<p class="wb-inv">L'exemple commence</p>
@@ -231,7 +231,7 @@
 							</div>
                         </div>
                      </div>
-                     <p>Voir d’autres exemples dans le critère de succès <a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast" lang="en-CA">1.4.11: Non-text Contrast</a> (en anglais seulement).</p>
+                     <p>Voir d’autres exemples dans le critère de succès <a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast" hreflang="en">1.4.11: Contraste du contenu non textuel (en anglais)</a>.</p>
                      <hr/>
                      <p class="small">Le mauvais exemple "Faible contraste avec une couleur adjacente (graphique)" est tiré de <a lang="en" href="https://webaim.org/articles/contrast/">Contrast and Colour Accessibility</a>, © WebAIM, 2021.</p>
                   </section>
@@ -248,7 +248,7 @@
                            <li>
 														<a lang="en" href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/visual-audio-contrast7.html" data-code="1.4.6">1.4.6 : Contraste (amélioré)</a> (Niveau AAA)  </li>
                            <li>
-														<a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast" data-code="1.4.11">1.4.11 : Contraste non textuel  (en anglais)</a>  </li>
+														<a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast" data-code="1.4.11">1.4.11 : Contraste du contenu non textuel  (en anglais)</a>  </li>
                         </ul>
                         <h3>Techniques</h3>
                         <ul>

--- a/learning/esdc-self-paced-web-accessibility-course/module7/hiding-content-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/hiding-content-fr.html
@@ -177,7 +177,7 @@
                            <li>
 														<a lang="en" href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/text-equiv-all.html" data-code="1.1.1">1.1.1 : Contenu non textuel</a> </li>
                            <li>
-														<a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus" data-code="1.4.13">1.4.13 : Contenu sur survol ou cible  (en anglais)</a> </li>
+														<a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus" data-code="1.4.13">1.4.13 : Contenu au survol ou au focus  (en anglais)</a> </li>
                         </ul>
                         <h3>Techniques</h3>
                         <ul>

--- a/learning/esdc-self-paced-web-accessibility-course/module7/introduction-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/introduction-fr.html
@@ -100,13 +100,13 @@
                         <summary class="bg-info">Ressources liées aux WCAG</summary>
                         <h3>Critères de succès</h3>
                         <ul>
-                           <li><a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content">1.1.1: Non-text Content</a> </li>
-                           <li><a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html">1.4.1: Use of Colour</a> </li>
-                           <li><a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum">1.4.3: Contrast (Minimum)</a> </li>
-                           <li><a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast">1.4.11: Non-text Contrast</a> </li>
-                           <li><a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing">1.4.12: Text Spacing</a> </li>
-                           <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus" lang="en-CA">1.4.13: Content on Hover or Focus</a> </li>
-                           <li><a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions">3.3.2: Labels or Instructions</a> </li>
+                           <li><a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/text-equiv-all.html">1.1.1 : Contenu non textuel</a> </li>
+                           <li><a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/visual-audio-contrast-without-color.html">1.4.1 : Utilisation de la couleur</a> </li>
+                           <li><a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/visual-audio-contrast-contrast.html">1.4.3 : Contraste (Minimum)</a> </li>
+                           <li><a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast">1.4.11 : Contraste du contenu non textuel (en anglais)</a> </li>
+                           <li><a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing">1.4.12 : Espacement du texte (en anglais)</a> </li>
+                           <li><a hreflang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus">1.4.13 : Contenu au survol ou au focus (en anglais)</a> </li>
+                           <li><a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/minimize-error-cues.html">3.3.2 : &#201;tiquettes ou instructions</a> </li>
                         </ul>
                      </details>
                   </section>

--- a/learning/esdc-self-paced-web-accessibility-course/module7/textspacing-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/textspacing-fr.html
@@ -145,7 +145,7 @@
                         </div>
                      </div>
                     <hr/>
-                    <p class="small">« Mauvais exemples : Espacement du texte » est tirée du critère de succès: <a lang="en" href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing">1.4.12: Text Spacing (Espacement du texte)</a> (en anglais seulement)</p>
+                    <p class="small">« Mauvais exemples : Espacement du texte » est tirée du critère de succès: <a href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing" hreflang="en">1.4.12: Espacement du texte</a> (en anglais seulement)</p>
                   </section>
                   <section>
                      <h2 id="textspacing-wcag" class="wb-inv">Ressources WCAG connexes</h2>

--- a/learning/esdc-self-paced-web-accessibility-course/module8/introduction-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/introduction-fr.html
@@ -75,14 +75,13 @@
 		<h2 id="resources1" class="wb-inv">Ressources WCAG connexes</h2>
 		<details class="mrgn-tp-lg">
 			<summary class="bg-info">Ressources WCAG connexes</summary>
-                        <p class="mrgn-tp-md">En anglais seulement.</p>
 			<h3>Critères de succès</h3>
 			<ul>
 				<li>
-					<a href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text" lang="en-CA">1.4.4: Resize text</a>
+					<a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/visual-audio-contrast-scale.html">1.4.4 : Redimensionnement du texte</a>
 				</li>
 				<li>
-					<a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow" lang="en-CA">1.4.10: Reflow</a>
+					<a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow" hreflang="en">1.4.10 : Redistribution (en anglais)</a>
 				</li>
 			</ul>
 		</details>

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-design-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-design-fr.html
@@ -414,7 +414,7 @@ section img {
 					<h3>Critères de succès</h3>
 					<ul>
 						<li>
-														<a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow" hreflang="en-CA" data-code="1.4.10">1.4.10 : Reformater  (en anglais)</a>
+														<a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow" hreflang="en-CA" data-code="1.4.10">1.4.10 : Redistribution  (en anglais)</a>
 													</li>
 					</ul>
 					<h3>Techniques</h3>

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-images-fr.html
@@ -329,7 +329,7 @@
 					<h3>Critères de succès</h3>
 					<ul>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html" hreflang="en-CA" data-code="1.4.10">1.4.10 : Reformater  (en anglais)</a>
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html" hreflang="en-CA" data-code="1.4.10">1.4.10 : Redistribution  (en anglais)</a>
 						</li>					
 					</ul>
 					<h3>Techniques</h3>

--- a/learning/esdc-self-paced-web-accessibility-course/module8/zoom-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/zoom-fr.html
@@ -277,7 +277,7 @@
 			<h4>Critères de succès</h4>
 			<ul>
 				<li>
-					<a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow" hreflang="en-CA" data-code="1.4.10">1.4.10 : Reformater  (en anglais)</a>
+					<a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow" hreflang="en-CA" data-code="1.4.10">1.4.10 : Redistribution  (en anglais)</a>
 				</li>
 			</ul>
 			<h4>Techniques</h4>

--- a/learning/esdc-self-paced-web-accessibility-course/module9/animation-motion-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/animation-motion-fr.html
@@ -219,7 +219,7 @@
 							<a href="https://www.w3.org/Translations/NOTE-UNDERSTANDING-WCAG20-fr/time-limits-pause.html" data-code="2.2.2">2.2.2 : Mettre en pause, arrêter, masquer</a>
 						</li>
 						<li>
-							<a href="https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html" hreflang="en-CA" data-code="2.3.3">2.3.3 : Animation provenant d’interactions  (en anglais)</a> (Niveau AAA)
+							<a href="https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html" hreflang="en-CA" data-code="2.3.3">2.3.3 : Animation résultant d’interactions  (en anglais)</a> (Niveau AAA)
 						</li>
 						
 					</ul>

--- a/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view-fr.html
@@ -113,7 +113,7 @@
 												<li data-code="2.1.1" data-level="A"><a href="#keyboard"><span class="code">2.1.1</span><span>: </span><span class="name">Clavier</span> <span class="level"> (niveau A)</span></a></li>
 												<li data-code="2.1.2" data-level="A"><a href="#no-keyboard-trap"><span class="code">2.1.2</span><span>: </span><span class="name">Pas de piège au clavier</span> <span class="level"> (niveau A)</span></a></li>
 												<li data-code="2.1.3" data-level="AAA"><a href="#keyboard-no-exception"><span class="code">2.1.3</span><span>: </span><span class="name">Clavier (sans exception)</span> <span class="level"> (niveau AAA)</span></a></li>
-												<li data-code="2.1.4" data-level="A"><a href="#character-key-shortcuts"><span class="code">2.1.4</span><span>: </span><span class="name">Raccourcis clavier de caractères</span> <span class="level"> (niveau A)</span></a></li>
+												<li data-code="2.1.4" data-level="A"><a href="#character-key-shortcuts"><span class="code">2.1.4</span><span>: </span><span class="name">Raccourcis clavier utilisant des caractères</span> <span class="level"> (niveau A)</span></a></li>
 											</ul>
 										</li>
 										<li data-code="2.2"><strong><span class="code">2.2</span><span>: </span><span class="name">Délai suffisant</span></strong><ul>
@@ -146,7 +146,7 @@
 										</li>
 										<li data-code="2.5"><strong><span class="code">2.5</span><span>: </span><span class="name">Modalités de saisie des données</span></strong><ul>
 												<li data-code="2.5.1" data-level="A"><a href="#pointer-gestures"><span class="code">2.5.1</span><span>: </span><span class="name">Gestes de commande du curseur</span> <span class="level"> (niveau A)</span></a></li>
-												<li data-code="2.5.2" data-level="A"><a href="#pointer-cancellation"><span class="code">2.5.2</span><span>: </span><span class="name">Annulation du curseur</span> <span class="level"> (niveau A)</span></a></li>
+												<li data-code="2.5.2" data-level="A"><a href="#pointer-cancellation"><span class="code">2.5.2</span><span>: </span><span class="name">Annulation de l’action du pointeur</span> <span class="level"> (niveau A)</span></a></li>
 												<li data-code="2.5.3" data-level="A"><a href="#label-in-name"><span class="code">2.5.3</span><span>: </span><span class="name">Étiquette dans le nom</span> <span class="level"> (niveau A)</span></a></li>
 												<li data-code="2.5.4" data-level="A"><a href="#motion-actuation"><span class="code">2.5.4</span><span>: </span><span class="name">Commande par le mouvement</span> <span class="level"> (niveau A)</span></a></li>
 												<li data-code="2.5.5" data-level="AAA"><a href="#target-size"><span class="code">2.5.5</span><span>: </span><span class="name">Taille de la cible</span> <span class="level"> (niveau AAA)</span></a></li>
@@ -1557,7 +1557,7 @@ exigence de conformité 5&nbsp;: non-interférence</a>
 				
 			</article>
 										<article class="criterion mrgn-bttm-lg" data-level="A" data-version="v21" data-code="2.1.4">
-				<h4 id="character-key-shortcuts"><span class="code">2.1.4</span><span>: </span><span class="name">Raccourcis clavier de caractères</span><span class="level"> (niveau A)</span></h4>
+				<h4 id="character-key-shortcuts"><span class="code">2.1.4</span><span>: </span><span class="name">Raccourcis clavier utilisant des caractères</span><span class="level"> (niveau A)</span></h4>
 				<details id="inner-33" class="grouped-inner mrgn-bttm-md on criterion">
 												<summary class="bg-info" tabindex="0">Description de 2.1.4</summary>
 												<blockquote class="mrgn-tp-md">


### PR DESCRIPTION
Updated our 2.1 translations with official translations
Updated the WCAG resources of three intro pages (mods 7, 8, 10) and three standalone links that had English WCAG link text, 
Deleted 2 instances of En anglais seulement paragraphs