### PR TITLE
updated links and paragraph text for auditor learning path indexs

### DIFF
--- a/learning/learning-path-for-auditors/index-fr.html
+++ b/learning/learning-path-for-auditors/index-fr.html
@@ -50,8 +50,12 @@
 
         <div class="row">
             <section class="col-md-6">
-                <h3 class="h5"><a href="./document-auditor-learning-path/index-fr.html">Parcours d'apprentissage de l'auditeur de documents</a></h3>
-                <p>Avec ce parcours d'apprentissage, vous aurez une compréhension de base des technologies sur lesquelles repose le Web, une compréhension de base de l'accessibilité en ce qui concerne le Web, les mobiles, les documents et, éventuellement, les ordinateurs de bureau, et vous saurez comment créer et évaluer des applications Internet riches. Aucun cours ne peut être exhaustif. La plupart des connaissances seront acquises par l'expérience. Ce parcours d'apprentissage posera les bases qui vous permettront de les développer au fur et à mesure que vous pratiquerez le développement Web et l'audit de l'accessibilité.</p>
+                <h3 class="h5"><a href="./document-auditor-learning-path/document-auditor-learning-path-fr.html">Parcours d'apprentissage de l'auditeur de documents</a></h3>
+                <p>Il s'agit d'un parcours d'apprentissage destiné à toute personne souhaitant devenir un auditeur d'accessibilité des documents. Ce parcours d'apprentissage comprend des cours sur les bases de l'accessibilité des documents et sur l'audit de l'accessibilité pour différents types de documents.</p>
+            </section>
+            <section class="col-md-6">
+                <h3 class="h5"><a href="./web-auditor-learning-path/web-auditor-learning-path-fr.html">Parcours d'apprentissage pour les auditeurs web</a></h3>
+                <p>Il s’agit d’un parcours d’apprentissage destiné à quiconque souhaite devenir vérificateur de l’accessibilité du Web. Ce parcours d’apprentissage comprend des cours sur les principes de base de l’accessibilité, le développement Web et la vérification de l’accessibilité pour les applications Web et mobiles.</p>
             </section>
         </div>
         <div id="def-preFooter"></div>

--- a/learning/learning-path-for-auditors/index.html
+++ b/learning/learning-path-for-auditors/index.html
@@ -49,15 +49,13 @@
         <h1 property="name" id="wb-cont">Learning Path for Auditors</h1>
         <div class="row wb-eqht">
             <section class="col-md-6">
-                <h3 class="h5"><a href="./document-auditor-learning-path/index.html">Document Auditor Learning Path</a></h3>
-                <p>With this learning path, you will have a basic understanding of the
-                    technologies that the Web is built on, a basic understanding of
-                    accessibility as it pertains to the Web, mobile, documents, and
-                    eventually desktop; and how to build and evaluate rich internet
-                    applications. No course can be exhaustive. Most knowledge will be
-                    gained through experience. This learning path will lay the
-                    foundation allowing you to build upon it as you practice web
-                    development and accessibility auditing.
+                <h3 class="h5"><a href="./document-auditor-learning-path/document-auditor-learning-path-en.html">Document Auditor Learning Path</a></h3>
+                <p>A learning path geared towards anyone wishing to become a document accessibility auditor. This learning path includes courses on document accessibility and accessibility auditing for various document types.
+                </p>
+            </section>
+            <section class="col-md-6">
+                <h3 class="h5"><a href="./web-auditor-learning-path/web-auditor-learning-path-en.html">Web Auditor Learning Path</a></h3>
+                <p>A learning path geared towards anyone wishing to become a web accessibility auditor. This learning path includes courses on basic accessibility principles, web development, and accessibility auditing for both web and mobile apps.
                 </p>
             </section>
         </div>


### PR DESCRIPTION
Updated links and paragraph text on  `/learning-path-for-auditors/index` pages to include the following html files that are using JSON data:

- `document-auditor-learning-path/document-auditor-learning-path-en.html`
- `document-auditor-learning-path/document-auditor-learning-path-fr.html`
- `/web-auditor-learning-path/web-auditor-learning-path-en.html`
- `/web-auditor-learning-path/web-auditor-learning-path-fr.html`