### PR TITLE
Add missing breadcrumbs

### DIFF
--- a/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path-en.html
+++ b/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path-en.html
@@ -45,6 +45,13 @@
             title: "Learning",
             href: "../../index.html",
           },
+          {
+            title: "Learning Path For Auditors",
+            href: "../index.html",
+          },
+          {
+            title: "Learning Path for Document Accessibility Auditors",       
+          },
         ],
         lngLinks: [
           {

--- a/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path-fr.html
+++ b/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path-fr.html
@@ -44,6 +44,13 @@
             title: "Apprentissage",
             href: "../../index-fr.html",
           },
+          {
+            title: "Parcours d'apprentissage pour les auditeurs",
+            href: "../index-fr.html",
+          },
+          {
+            title: "Parcours d'apprentissage pour les auditeurs de documents",        
+          },
         ],
         lngLinks: [
           {

--- a/learning/learning-path-for-auditors/index-fr.html
+++ b/learning/learning-path-for-auditors/index-fr.html
@@ -36,6 +36,8 @@
             }, {
                 "title" : "Apprentissage",
                 "href" : "../index-fr.html"
+            }, {
+                "title" : "Parcours d'apprentissage pour les auditeurs",
             }],
             "lngLinks": [{
                 "lang": "en",

--- a/learning/learning-path-for-auditors/index.html
+++ b/learning/learning-path-for-auditors/index.html
@@ -36,6 +36,8 @@
             }, {
                 "title" : "Learning",
                 "href" : "../index.html"
+            }, {
+                "title" : "Learning Path for Auditors",
             }],
             "lngLinks": [{
                 "lang": "fr",


### PR DESCRIPTION
Updated breadcrumb links for:

- `/learning-path-for-auditor/index.html`
- `/learning-path-for-auditor/index-fr.html`
- `/document-auditor-learning-path/document-auditor-learning-path-en.html`
- `/document-auditor-learning-path/document-auditor-learning-path-fr.html`
