### PR TITLE
fixed broken MS_Document_Audit_Report link by changing path

### DIFF
--- a/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path.json
+++ b/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path.json
@@ -507,8 +507,8 @@
             "fr": "Sans objet"
           },
           "purpose": {
-            "en": "Perform audits using the <a href=\"https://bati-itao.github.io/learning/document-auditor-learning-path/MSDocument_Audit_Report_EN.docx\">MSDocument Audit Report</a>. Produce one report per document.",
-            "fr": "Effectuer des audits en utilisant l’outil <a href=\"https://bati-itao.github.io/learning/document-auditor-learning-path/MSDocument_Audit_Report_FR.docx\">MSDocument Audit Report</a>. Produire un rapport pour chaque document."
+            "en": "Perform audits using the <a href=\"./MSDocument_Audit_Report_EN.docx\">MSDocument Audit Report</a>. Produce one report per document.",
+            "fr": "Effectuer des audits en utilisant l’outil <a href=\"./MSDocument_Audit_Report_FR.docx\">MSDocument Audit Report</a>. Produire un rapport pour chaque document."
           },
           "goal": null,
           "materials": {


### PR DESCRIPTION
In Block B, Item 4:

- Fixed broken link by changing path to `./MSDocument_Audit_Report_EN.docx` & `./MSDocument_Audit_Report_FR.docx`