### PR TITLE
moved temporary icon fix to bati-itao.min script

### DIFF
--- a/scripts/bati-itao.min.js
+++ b/scripts/bati-itao.min.js
@@ -1,1 +1,10 @@
+/*Temporary Icon Fix*/
+let link = document.createElement('link');
+link.rel ="stylesheet";
+link.href = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css";
+link.integrity = "sha512-q3eWabyZPc1XTCmF+8/LuE1ozpg5xxn7iO89yfSOd5/oKvyqLngoNGsx8jq92Y8eXJ/IRxQbEC+FGSYxtk2oiw==";
+link.crossOrigin ="anonymous";
+link.referrerPolicy ="no-referrer";
+document.head.appendChild(link);
+
 $(document).on("wb-ready.wb",function(t){$(".printMe").click(function(){window.print()}),$(".expand").each(function(){this.setAttribute("style","height:"+this.scrollHeight+"px;overflow-y:hidden;")}).on("input",function(){this.style.height="auto",this.style.height=this.scrollHeight+"px"}),$("#wb-info .landscape a").prepend("<i class='fab fa-3x fa-github mrgn-rght-md' aria-hidden='true'></i>")});

--- a/teams/svatic-ictaas/index-en.html
+++ b/teams/svatic-ictaas/index-en.html
@@ -25,8 +25,6 @@
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/style.css" />
     <link rel="stylesheet" href="../styles/custom.css" />
-    <!--Temporary icon fix-->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css" integrity="sha512-q3eWabyZPc1XTCmF+8/LuE1ozpg5xxn7iO89yfSOd5/oKvyqLngoNGsx8jq92Y8eXJ/IRxQbEC+FGSYxtk2oiw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body vocab="https://schema.org/" typeof="WebPage">
     <div id="def-top"></div>

--- a/teams/svatic-ictaas/index-fr.html
+++ b/teams/svatic-ictaas/index-fr.html
@@ -24,8 +24,6 @@
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/style.css" />
     <link rel="stylesheet" href="../styles/custom.css" />
-    <!--Temporary icon fix-->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css" integrity="sha512-q3eWabyZPc1XTCmF+8/LuE1ozpg5xxn7iO89yfSOd5/oKvyqLngoNGsx8jq92Y8eXJ/IRxQbEC+FGSYxtk2oiw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body vocab="https://schema.org/" typeof="WebPage">
     <div id="def-top"></div>


### PR DESCRIPTION
- Removed the temporary font awesome icon cdn library `<link>` tags from team page
- Added a new temporary icon fix to the bati-itao.min.js script to create a new `<link>` for the font awesome cdn on all pages
- This is still a temporary fix for the icons disappearing.