### PR TITLE
fixed APG links with full URL

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/module12/apg-wet-inventory.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module12/apg-wet-inventory.html
@@ -18,19 +18,19 @@
 <nav>
 	<ul>
 		<li><a href="#examples_by_pattern_name">ARIA patterns without dedicated roles and their WET equivalents</a></li>
-		<li><a href="examples_by_role_label">Examples by role</a></li>
+		<li><a href="#examples_by_role_label">Examples by role</a></li>
 		<li><a href="#examples_by_props_label">Examples by property and state</a></li>
 	</ul>
 </nav>
 
-<h2 id="examples_by_pattern_name">ARIA patterns without dedicated roles and their WET equivalents</h2>
+<h2 id="examples_by_pattern_name">APG patterns without dedicated roles and their WET equivalents</h2>
 <p>Some ARIA patterns, like Accordion and Disclosure, don't have dedicated roles. Their child elements use roles (like button, region).</p>
 <table aria-labelledby="examples_by_role_label" class="data attributes">
 		
         <thead>
           <tr>
             <th>Pattern</th>
-            <th>WAI examples</th>
+            <th>APG examples</th>
             <th>WET examples</th>
           </tr>
         </thead>
@@ -61,7 +61,7 @@
         <thead>
           <tr>
             <th>Role</th>
-            <th>WAI examples</th>
+            <th>APG examples</th>
             <th>WET examples</th>
           </tr>
         </thead>
@@ -80,14 +80,14 @@
           </tr>
           <tr>
             <td><code>alertdialog</code></td>
-            <td><a href="dialog-modal/alertdialog.html">Alert Dialog</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/alertdialog.html">Alert Dialog</a></td>
             <td>
 				<p>No example use in WET.</p>
             </td>
           </tr>
           <tr>
             <td><code>article</code></td>
-            <td><a href="feed/feed.html">Feed</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/feed/feed.html">Feed</a></td>
             <td>
 				<p>No example use in WET.</p>
             </td>
@@ -122,7 +122,7 @@
           </tr>
           <tr>
             <td><code>cell</code></td>
-            <td><a href="table/table.html">Table</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/table/table.html">Table</a></td>
             <td>
 				<p>No example use in WET.</p>
             </td>
@@ -139,7 +139,7 @@
           </tr>
           <tr>
             <td><code>columnheader</code></td>
-            <td><a href="table/table.html">Table</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/table/table.html">Table</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -160,7 +160,7 @@
           </tr>
           <tr>
             <td><code>complementary</code></td>
-            <td><a href="landmarks/complementary.html">Complementary Landmark</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/landmarks/complementary.html">Complementary Landmark</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -187,12 +187,12 @@
           </tr>
           <tr>
             <td><code>feed</code></td>
-            <td><a href="feed/feed.html">Feed</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/feed/feed.html">Feed</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
             <td><code>form</code></td>
-            <td><a href="landmarks/form.html">Form Landmark</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/landmarks/form.html">Form Landmark</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -239,7 +239,7 @@
           </tr>
           <tr>
             <td><code>link</code></td>
-            <td><a href="link/link.html">Link</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/link/link.html">Link</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -260,7 +260,7 @@
           </tr>
           <tr>
             <td><code>main</code></td>
-            <td><a href="landmarks/main.html">Main Landmark</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/landmarks/main.html">Main Landmark</a></td>
             <td>Used incorrectly (redundantly) on default template.</td>
           </tr>
           <tr>
@@ -304,7 +304,7 @@
           </tr>
           <tr>
             <td><code>menuitemcheckbox</code></td>
-            <td><a href="menubar/menubar-editor.html">Editor Menubar</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/menubar/menubar-editor.html">Editor Menubar</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -319,7 +319,7 @@
           </tr>
           <tr>
             <td><code>meter</code></td>
-            <td><a href="meter/meter.html">Meter</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/meter/meter.html">Meter</a></td>
             <td>Meter polyfill documentation claims to emulate the HTML5 meter element with generic HTML and ARIA, but it doesn't use any of the ARIA attributes.</td>
           </tr>
           <tr>
@@ -423,17 +423,17 @@
           </tr>
           <tr>
             <td><code>rowgroup</code></td>
-            <td><a href="table/table.html">Table</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/table/table.html">Table</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
             <td><code>search</code></td>
-            <td><a href="landmarks/search.html">Search Landmark</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/landmarks/search.html">Search Landmark</a></td>
             <td>No example use in WET (other than on the WET site's own search form).</td>
           </tr>
           <tr>
             <td><code>separator</code></td>
-            <td><a href="menubar/menubar-editor.html">Editor Menubar</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/menubar/menubar-editor.html">Editor Menubar</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -485,7 +485,7 @@
           </tr>
           <tr>
             <td><code>table</code></td>
-            <td><a href="table/table.html">Table</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/table/table.html">Table</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -512,7 +512,7 @@
           </tr>
           <tr>
             <td><code>toolbar</code></td>
-            <td><a href="toolbar/toolbar.html">Toolbar</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/toolbar/toolbar.html">Toolbar</a></td>
             <td>Toolbars in buttons. Uses the toolbar role but lacks the rest of the roles and attributes.</td>
           </tr>
           <tr>
@@ -528,7 +528,7 @@
           </tr>
           <tr>
             <td><code>treegrid</code></td>
-            <td><a href="treegrid/treegrid-1.html">Treegrid Email Inbox</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/treegrid/treegrid-1.html">Treegrid Email Inbox</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -543,13 +543,16 @@
             <td><p>No example use in WET.</p></td>
           </tr></tbody>
       </table>
+
+
+
       
       <h2 id="examples_by_props_label">Examples by property and state</h2>
 <table aria-labelledby="examples_by_props_label" class="data attributes">
         <thead>
           <tr>
             <th class="attribute">Property or State</th>
-            <th>WAI examples</th>
+            <th>APG examples</th>
             <th>WET examples</th>
           </tr>
         </thead>
@@ -575,7 +578,7 @@
           </tr>
           <tr>
             <td><code>aria-atomic</code></td>
-            <td><a href="alert/alert.html">Alert</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/alert/alert.html">Alert</a></td>
             <td>Used once, on the summary of results of the WET <a href="https://wet-boew.github.io/v4.0-ci/demos/wamethod/wamethod-AA-en.html">Web Accessibility Assessment Methodology (Level AA)</a>. A live region is set incorrectly on each of the five summary cells instead of their parent rows, where aria-atomic would include the row header identifying the statistic. Changing a radio box status for any of the success criteria causes a cascade of meaningless percentage value declarations, lacking their labels.</td>
           </tr>
           <tr>
@@ -593,7 +596,7 @@
           </tr>
           <tr>
             <td><code>aria-busy</code></td>
-            <td><a href="feed/feed.html">Feed</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/feed/feed.html">Feed</a></td>
             <td>Used once, on the summary of results of the WET <a href="https://wet-boew.github.io/v4.0-ci/demos/wamethod/wamethod-AA-en.html">Web Accessibility Assessment Methodology (Level AA)</a>. The JavaScript sets the live regions in the summary table to aria-busy="true" before modifying the values, then sets it to aria-busy="false". A live region is set incorrectly on each of the five summary cells instead of their parent rows, where aria-atomic would include the row header identifying the statistic. Changing a radio box status for any of the success criteria causes a cascade of meaningless percentage value declarations, lacking their labels.</td>
           </tr>
           <tr>
@@ -615,12 +618,12 @@
           </tr>
           <tr>
             <td><code>aria-colcount</code></td>
-            <td><a href="grid/dataGrids.html">Data Grid</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/grid/dataGrids.html">Data Grid</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
             <td><code>aria-colindex</code></td>
-            <td><a href="grid/dataGrids.html">Data Grid</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/grid/dataGrids.html">Data Grid</a></td>
             <td><p>No example use in WET.</p></td>
           </tr>
           <tr>
@@ -928,21 +931,21 @@
           </tr>
           <tr>
             <td><code>aria-multiselectable</code></td>
-            <td><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></td>
             <td>
 				<p>No example use in WET.</p>
             </td>
           </tr>
           <tr>
             <td><code>aria-orientation</code></td>
-            <td><a href="slider/slider-temperature.html">Vertical Temperature Slider</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/slider/slider-temperature.html">Vertical Temperature Slider</a></td>
             <td>
 				<p>No example use in WET.</p>
             </td>
           </tr>
           <tr>
             <td><code>aria-owns</code></td>
-            <td><a href="treeview/treeview-navigation.html">Navigation Treeview</a></td>
+            <td><a href="https://www.w3.org/WAI/ARIA/apg/example-index/treeview/treeview-navigation.html">Navigation Treeview</a></td>
             <td>
 				<p>Used by the <a href="https://wet-boew.github.io/v4.0-ci/demos/datalist/datalist-en.html">datalist polyfill</a> component though it's not part of the APG pattern. The polyfill implements the ARIA Combobox pattern in browsers that don't support the HTML5 input <code>list</code> attribute and the <code>datalist</code> element.</p>
             </td>


### PR DESCRIPTION
Several URLs were local and needed the rest of the path.
Renamed "WAI examples" to "APG examples"
