### PR TITLE
removed placeholders and empty a tags

### DIFF
--- a/learning/awareness/training-fr.html
+++ b/learning/awareness/training-fr.html
@@ -67,7 +67,7 @@
               </thead>
               <tbody>
                 <tr class="gradeX">
-                  <td>...</td>
+                  <td></td>
                   <td>Coaching en matière d'accessibilité pour les développeurs</td>
                   <td><a href="../awareness/documents/Accessibility Coaching Services for Developers.docx">Accessibility Coaching<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Lien interne</span></a></td>
                   <td><a href="../awareness/documents/Accessibility Coaching Services for Developers_Jan 10th 2022.msg">IITB_Accessibilty Coaching _ 2022 BILINGUAL<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Lien interne</span></a></td>
@@ -75,27 +75,27 @@
                   <td>Accessibility Compliance Project</td>
                 </tr>
                 <tr class="gradeX">
-                  <td>...</td>
+                  <td></td>
                   <td>L'accessibilité pour le développement Web</td>
                   <td><a href="https://esdc.sabacloud.com/Saba/Web_wdk/CA1PRD0006/index/prelogin.rdf?spfUrl=%2FSaba%2FWeb_spf%2FCA1PRD0006%2Fapp%2Fme%2Flearningeventdetail%2Fcours000000000109145%3FregId%3Dregdw000000002087046%26returnurl%3Dcommon%252Fsearchresults%252Faccessibility%252FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY">Accessibility - Information and Communication Technologies Accessibility for Web Development<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Lien interne</span></a></td>
-                  <td><a href="">... <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Lien interne</span></a></td>
-                  <td>...</td>
+                  <td></td>
+                  <td></td>
                   <td>ICT Accessibility Initiative</td>
                 </tr>
                 <tr class="gradeX">
-                  <td>...</td>
+                  <td></td>
                   <td>Apprendre l'accessibilité pour MS Office</td>
                   <td><a href="https://esdc.sabacloud.com/Saba/Web_wdk/CA1PRD0006/index/prelogin.rdf?spfUrl=%2FSaba%2FWeb_spf%2FCA1PRD0006%2Fapp%2Fme%2Flearningeventdetail%2Fcours000000000091747%3Freturnurl%3Dcommon%252Fsearchresults%252Faccessibility%252FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY&returnurl=common%2Fsearchresults%2Faccessibility%2FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY">Accessibility - Creating accessible content using Microsoft Office 2016<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Lien interne</span></a></td>
-                  <td><a href="">...<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Lien interne</span></a></td>
-                  <td>...</td>
+                  <td></td>
+                  <td></td>
                   <td>ICT Accessibility Initiative</td>
                 </tr>
                 <tr class="gradeX">
-                  <td>...</td>
+                  <td></td>
                   <td>Apprendre à créer des documents PDF accessibles</td>
                   <td><a href="https://esdc.sabacloud.com/Saba/Web_wdk/CA1PRD0006/index/prelogin.rdf?spfUrl=%2FSaba%2FWeb_spf%2FCA1PRD0006%2Fapp%2Fme%2Flearningeventdetail%2Fcours000000000104225%3FregId%3Dregdw000000001970840%26returnurl%3Dcommon%252Fsearchresults%252Faccessibility%252FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY&regId=regdw000000001970840&returnurl=common%2Fsearchresults%2Faccessibility%2FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY">Accessibility – Create Accessible PDF Documents<i class="fas fa-external-link-square-alt"></i><span class="wb-inv"> Internal link</span></a></td>
-                  <td><a href="">...<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a></td>
-                  <td>...</td>
+                  <td></td>
+                  <td></td>
                   <td>ICT Accessibility Initiative</td>
                 </tr>
               </tbody>

--- a/learning/awareness/training.html
+++ b/learning/awareness/training.html
@@ -71,7 +71,7 @@
               </thead>
               <tbody>
                 <tr class="gradeX">
-                  <td>...</td>
+                  <td></td>
                   <td>IT Coaching Accessibilty for Developers</td>
                   <td><a href="../awareness/documents/Accessibility Coaching Services for Developers (1).docx">Accessibility Coaching<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a></td>
                   <td><a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210225.shtml">IITB_Accessibilty Coaching _ 2022 BILINGUAL<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a></td>
@@ -79,27 +79,27 @@
                   <td>Accessibility Compliance Project</td>
                 </tr>
                 <tr class="gradeX">
-                  <td>...</td>
+                  <td></td>
                   <td>Accessibility for Web Development</td>
                   <td><a href="https://esdc.sabacloud.com/Saba/Web_wdk/CA1PRD0006/index/prelogin.rdf?spfUrl=%2FSaba%2FWeb_spf%2FCA1PRD0006%2Fapp%2Fme%2Flearningeventdetail%2Fcours000000000109145%3FregId%3Dregdw000000002087046%26returnurl%3Dcommon%252Fsearchresults%252Faccessibility%252FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY">Accessibility - Information and Communication Technologies Accessibility for Web Development<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a></td>
-                  <td><a href="">... <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a></td>
-                  <td>...</td>
+                  <td></td>
+                  <td></td>
                   <td>ICT Accessibility Initiative</td>
                 </tr>
                 <tr class="gradeX">
-                  <td>...</td>
+                  <td></td>
                   <td>Learn Accessibilty for MS Office</td>
                   <td><a href="https://esdc.sabacloud.com/Saba/Web_wdk/CA1PRD0006/index/prelogin.rdf?spfUrl=%2FSaba%2FWeb_spf%2FCA1PRD0006%2Fapp%2Fme%2Flearningeventdetail%2Fcours000000000091747%3Freturnurl%3Dcommon%252Fsearchresults%252Faccessibility%252FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY&returnurl=common%2Fsearchresults%2Faccessibility%2FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY">Accessibility - Creating accessible content using Microsoft Office 2016<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a></td>
-                  <td><a href="">...<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a></td>
-                  <td>...</td>
+                  <td></td>
+                  <td></td>
                   <td>ICT Accessibility Initiative</td>
                 </tr>
                 <tr class="gradeX">
-                  <td>...</td>
+                  <td></td>
                   <td>Learn Accessibilty for MS Office</td>
                   <td><a href="https://esdc.sabacloud.com/Saba/Web_wdk/CA1PRD0006/index/prelogin.rdf?spfUrl=%2FSaba%2FWeb_spf%2FCA1PRD0006%2Fapp%2Fme%2Flearningeventdetail%2Fcours000000000104225%3FregId%3Dregdw000000001970840%26returnurl%3Dcommon%252Fsearchresults%252Faccessibility%252FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY&regId=regdw000000001970840&returnurl=common%2Fsearchresults%2Faccessibility%2FLEARNINGEVENT%2COFFERINGTEMPLATE%2CCERTIFICATION%2CCURRICULUM%2COFFERING%2CPACKAGE%2CLXPCONTENT%2CLEARNINGPATHWAY">Accessibility - Create Accessible PDF Documents <i class="fas fa-external-link-square-alt"></i><span class="wb-inv"> Internal link</span></a></td>
-                  <td><a href="">... <i class="fas fa-external-link-square-alt"></i><span class="wb-inv"> Internal link</span></a></td>
-                  <td>...</td>
+                  <td></td>
+                  <td></td>
                   <td>ICT Accessibility Initiative</td>
                 </tr>
               </tbody>


### PR DESCRIPTION
Removed placeholders and empty `<a>`  tags from the training pages (English and French)