### PR TITLE
fixed breadcrumb path to redirect back to home

### DIFF
--- a/learning/awareness/index.html
+++ b/learning/awareness/index.html
@@ -33,7 +33,7 @@
             }],
            "breadcrumbs" : [{
             "title": "Home",
-                "href" : "../index.html"
+                "href" : "../../index.html"
             }, {
                 "title" : "Learning",
                 "href" : "../index.html"


### PR DESCRIPTION
Fixed the breadcrumb for the home link to properly redirect back to the ITAO index page.