### PR TITLE
added missing info alerts for external link on  events + training (fr)

### DIFF
--- a/awareness/awareness-event-fr.html
+++ b/awareness/awareness-event-fr.html
@@ -53,6 +53,7 @@
         <div class="row">
           <main role="main" property="mainContentOfPage" class="col-md-9 col-md-push-3">
             <h1 property="name" id="wb-cont">Événement</h1>
+            <div data-wb-ajax='{"url": "https://bati-itao.github.io/ajax/links-esdc-goc-network-fr.html","type": "replace"}'></div>
             <div class="row mrgn-tp-sm mrgn-bttm-lg">
               <p>Voici des événements de sensibilisation offerts par le Bureau de l’accessibilité des TI. Vous aurez l’occasion d’approfondir vos connaissances sur la communauté présentant divers handicaps ainsi que du contenu relié à l'accessibilité.</p>
       </div>

--- a/awareness/training-fr.html
+++ b/awareness/training-fr.html
@@ -53,6 +53,7 @@
         <div class="row">
           <main role="main" property="mainContentOfPage" class="col-md-9 col-md-push-3">
             <h1 property="name" id="wb-cont">Formations</h1>
+            <div data-wb-ajax='{"url": "https://bati-itao.github.io/ajax/links-esdc-goc-network-fr.html","type": "replace"}'></div>
             <div class="row mrgn-tp-sm mrgn-bttm-lg">
               <p>Le but de ces formations est de développer et créer des documents et applications accessibles ainsi que d’approfondir notre connaissance sur les méthodes technologiques adaptatives utilisées par les personnes ayant des limitations fonctionnelles.</p>
       </div>


### PR DESCRIPTION
Added missing info alerts messages for external link usage. Added to `awareness-events-fr.html` & `training-fr.html`