### PR TITLE
fixed #1261 broken link

### DIFF
--- a/learning/learning-path-for-auditors/web-auditor-learning-path/web-auditor-learning-path.json
+++ b/learning/learning-path-for-auditors/web-auditor-learning-path/web-auditor-learning-path.json
@@ -549,25 +549,17 @@
               "fr": "Comprendre les principes fondamentaux des vérifications de l’accessibilité."
             },
             "materials": {
-              "en": "Register for the following courses for their next availability: <ul><li>Long term: {{urls[0]}} through CSPS (Canada School of the Public Service)</li><li>Short term: {{urls[1]}} in Saba taught by ITAO.</li></ul>",
-              "fr": "Inscrivez-vous aux cours suivants, en vue des prochaines séances. <ul><li>Long terme :  {{urls[2]}} par l’entremise de l’EFPC (École de la fonction publique du Canada).</li><li>Court terme : {{urls[3]}} dans Saba, dispensé par le BATI.</li></ul>"
+              "en": "Register for the following courses for their next availability: <ul><li>{{urls[0]}} in Saba taught by ITAO.</li></ul>",
+              "fr": "Inscrivez-vous aux cours suivants, en vue des prochaines séances. <ul><li>{{urls[1]}} dans Saba, dispensé par le BATI.</li></ul>"
             },
             "activity": null,
             "urls": [
               {
-                "url": "https://learn-apprendre.csps-efpc.gc.ca/",
-                "text": "T716: Web Accessibility for Canada.ca"
-              },
-              {
-                "url": "https://learn-apprendre.csps-efpc.gc.ca/",
+                "url": "https://esdc.sabacloud.com/Saba/Web_spf/CA1PRD0006/app/me/learningeventdetail/cours000000000109145?returnurl=common%2Fsearchresults%2Faccessibility%20for%20web%20development%2FLEARNINGEVENT,OFFERINGTEMPLATE,CERTIFICATION,CURRICULUM,PLAYLIST,OFFERING,PACKAGE,LXPCONTENT,LEARNINGPATHWAY%3FembeddedInTorque%3Dtrue",
                 "text": "Accessibility - Information and Communication Technologies Accessibility for Web Development"
               },
               {
-                "url": "https://learn-apprendre.csps-efpc.gc.ca/",
-                "text": "T716 : Accessibilité du Web pour Canada.ca"
-              },
-              {
-                "url": "https://learn-apprendre.csps-efpc.gc.ca/",
+                "url": "https://esdc.sabacloud.com/Saba/Web_spf/CA1PRD0006/app/me/learningeventdetail/cours000000000109145?returnurl=common%2Fsearchresults%2Faccessibility%20for%20web%20development%2FLEARNINGEVENT,OFFERINGTEMPLATE,CERTIFICATION,CURRICULUM,PLAYLIST,OFFERING,PACKAGE,LXPCONTENT,LEARNINGPATHWAY%3FembeddedInTorque%3Dtrue",
                 "text": "Accessibilité aux technologies de l’information et des communications pour le développement Web"
               }
             ],


### PR DESCRIPTION
Fixed #1261 

-Removed T716 course as it is no longer available
-Updated path for ICT Web Accessibility Course with proper SABA link