### PR TITLE
Removed link from internal link icon text as NVDA announces link 

### DIFF
--- a/awareness/upcoming-events.html
+++ b/awareness/upcoming-events.html
@@ -93,7 +93,7 @@
         </ul>
         <p>
           Don’t have a Saba account? No problem! - just follow <a href="https://iservice.prv/eng/college/saba/first-time.shtml">Instructions to access SABA account 
-            <i class="fas fa-external-link-square-alt"><span class="wb-inv">Internal link</span></i></a>
+            <i class="fas fa-external-link-square-alt"><span class="wb-inv">Internal</span></i></a>
             and register to the events.
         </p>
                       </div>


### PR DESCRIPTION
Removed link from internal link icon text as NVDA announces link to avoid redundancy.