### PR TITLE
2024 articles changes

### DIFF
--- a/awareness/archived-articles-fr.html
+++ b/awareness/archived-articles-fr.html
@@ -71,21 +71,21 @@
             Articles publiés pour le mois de:
           </p>
 
-          <h2><a href="#y2021">2021</a></h2>
-						
+						<h2><a href="#y2023">2023</a></h2>
+										
 						<ul class="list-unstyled colcount-sm-2 colcount-md-3 colcount-lg-4">
-  							<!-- <li><a href="#m101">Janvier</a></li> -->
-  							<li><a href="#m102">Février</a></li>
-  							<!-- <li><a href="#m103">Mars</a></li> -->
-  							<!-- <li><a href="#m104">Avril</a></li> -->
-							<li><a href="#m105">Mai</a></li>
-							<li><a href="#m106">Juin</a></li>
-							<li><a href="#m107">Juillet</a></li>
-							<!-- <li><a href="#m108">Août</a></li> -->
-							<li><a href="#m109">Septembre</a></li>
-							<li><a href="#m110">Octobre</a></li>
-							<li><a href="#m111">Novembre</a></li>
-							<li><a href="#m112">Décembre</a></li>
+							<li><a href="#m301">Janvier</a></li>
+							<li><a href="#m302">Février</a></li>
+							<li><a href="#m303">Mars</a></li>
+							<li><a href="#m304">Avril</a></li>
+							<li><a href="#m305">Mai</a></li>
+							<li><a href="#m306">Juin</a></li>
+							<li><a href="#m307">Juillet</a></li>
+							<!-- <li><a href="#m308">Août</a></li> -->
+							<li><a href="#m309">Septembre</a></li>
+							<li><a href="#m310">Octobre</a></li>
+							<li><a href="#m311">Novembre</a></li>
+							<li><a href="#m312">Décembre</a></li>
 						</ul>
 
 						<h2><a href="#y2022">2022</a></h2>
@@ -104,83 +104,124 @@
 							<li><a href="#m211">Novembre</a></li>
 							<li><a href="#m212">Décembre</a></li>
 						</ul>
-					
+
+						<h2><a href="#y2021">2021</a></h2>
+						
+						<ul class="list-unstyled colcount-sm-2 colcount-md-3 colcount-lg-4">
+  							<!-- <li><a href="#m101">Janvier</a></li> -->
+  							<li><a href="#m102">Février</a></li>
+  							<!-- <li><a href="#m103">Mars</a></li> -->
+  							<!-- <li><a href="#m104">Avril</a></li> -->
+							<li><a href="#m105">Mai</a></li>
+							<li><a href="#m106">Juin</a></li>
+							<li><a href="#m107">Juillet</a></li>
+							<!-- <li><a href="#m108">Août</a></li> -->
+							<li><a href="#m109">Septembre</a></li>
+							<li><a href="#m110">Octobre</a></li>
+							<li><a href="#m111">Novembre</a></li>
+							<li><a href="#m112">Décembre</a></li>
+						</ul>
 					
 					<p><br/>
 						Articles publié pour le mois de:
 					</p>
 
-					<h2 id="y2021">2021</h2>
-
-					<h3 id="m02">Février</h3>
+					<!-- Articles pour 2023 -->
+					
+					<h2 id="y2023">2023</h2>
+					<h3 id="m301">Janvier</h3>
 					<ul>
 						<li>
-							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210225.shtml">Journée internationale de sensibilisation aux microtraumatismes répétés <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/world-braille-day-fr.html">Journée Mondiale du Braille</a>
 						</li>
 					</ul>
 
-					<h3 id="m05">Mai</h3>
+					<h3 id="m302">Février</h3>
 					<ul>
 						<li>
-							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210513.shtml">Journée mondiale de sensibilisation à l'accessibilité <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/world-cancer-day-fr.html">Journée Mondiale contre le Cancer </a>
 						</li>
 						<li>
-							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210527.shtml">Semaine de l'accessibilité <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/rsi-awareness-day-fr.html">Journée de sensibilisation aux microtraumatismes répétés</a>
+						</li>
+					</ul>
+
+					<h3 id="m303">Mars</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/developmental-disabilities-awareness-month-fr.html">Mois de Sensibilisation aux Troubles du Développement</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/world-autism-awareness-day-fr.html">Journée mondiale de sensibilisation à lautisme</a>
 						</li>
 					</ul>
 					
-					<h3 id="m06">Juin</h3>
+					<h3 id="m304">Avril</h3>
 					<ul>
 						<li>
-							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210625.shtml">Association internationale des professionnels de l'accessibilité <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/fnd-awareness-day-fr.html">Journée internationale de sensibilisation aux troubles neurologiques fonctionnels</a>
 						</li>
 					</ul>
-
-					<h3 id="m07">Juillet</h3>
-					<ul>
-						<li>
-							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210708.shtml">Loi sur l'accessibilité du Canada - 2 ans d'existence <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210729.shtml">Semaine internationale du chien d'assistance <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m09">Septembre</h3>
-					<ul>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210909.shtml">Semaine internationale des sourds <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m10">Octobre</h3>
-					<ul>
-						<li>
-							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211008.shtml">Mois de sensibilisation à l'emploi des personnes handicapées <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211015.shtml">Journée internationale du langage clair <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m11">Novembre</h3>
-					<ul>	
-						<li>
-							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211108.shtml">Langue des signes/ Session COTS <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211122.shtml">Mois de sensibilisation aux handicaps autochtones <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m12">Décembre</h3>
-					<ul>	
-						<li>
-							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211220.shtml#k1">Section Kudos <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
 					
+					<h3 id="m305">Mai</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/gaad-fr.html">Journée mondiale de sensibilisation à laccessibilité</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/mci-eod-workplace-fr.html">Trouble cognitif léger (TCL) et démence dapparition précoce (DAP) en milieu de travail</a>
+						</li>
+					</ul>
+					
+					<h3 id="m306">Juin</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/naaw-fr.html">Semaine nationale de l'accessibilité</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/creating-an-accessible-outlook-email-fr.html">Créer un courriel Outlook accessible</a>
+						</li>
+					</ul>
+
+					<h3 id="m307">Juillet</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/accessibility-tools-and-adaptive-technology-for-neurodiverse-employees-fr.html">Outils d'Accessibilité et Technologie d'Adaptation pour les Employés Neurodivers</a>
+						</li>
+					</ul>
+
+					<h3 id="m309">Septembre</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/national-service-dog-month-fr.html">Mois National des Chiens d'Assistance</a>
+						</li>
+            			<li>
+              				<a href="../awareness/articles/accessibility-tools-and-adaptive-technology-for-deaf-fr.html">Outils d'Accessibilité et Technologie Adaptée pour les Employés Sourds, devenus sourds ou Malentendants</a>
+            			</li>
+					</ul>
+
+          			<h3 id="m310">Octobre</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/ndeam-fr.html">Mois national de la sensibilisation à l'emploi des personnes en situation de handicap</a>
+						</li>
+					</ul>
+
+					<h3 id="m311">Novembre</h3>
+					<ul>
+            			<li>
+              				<a href="../awareness/articles/world-sight-day-fr.html">Journée Mondiale de la Vue: Améliorer l'accessibilité du lieu de travail - Outils et technologies adaptées pour la vision des employés</a>
+            			</li>
+					</ul>
+
+          			<h3 id="m312">Décembre</h3>
+					<ul>
+            			<li>
+              				<a href="../awareness/articles/colour-contrast-analyzer-tools-fr.html">Rendre le contenu accessible avec les outils du « Colour Contrast Analyzer »</a>
+            			</li>
+					</ul>
+
+					<!-- Articles pour 2022 -->
 
 					<h2 id="y2022">2022</h2>
 					<h3 id="m201">Janvier</h3>
@@ -271,6 +312,78 @@
 					<ul>
 						<li>
 							<a href="https://esdc.prv/en/iitb/corporate/news/2022/20221212.shtml">Vacances estivales et accessibilité Promotion de la sensibilisation de GitHub  <i class="fas fa-external-link-square-alt"></i><span class="wb-inv"> Internal link</span></a>
+						</li>
+					</ul>
+
+					<!-- Articles pour 2021 -->
+
+					<h2 id="y2021">2021</h2>
+
+					<h3 id="m02">Février</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210225.shtml">Journée internationale de sensibilisation aux microtraumatismes répétés <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m05">Mai</h3>
+					<ul>
+						<li>
+							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210513.shtml">Journée mondiale de sensibilisation à l'accessibilité <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210527.shtml">Semaine de l'accessibilité <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+					
+					<h3 id="m06">Juin</h3>
+					<ul>
+						<li>
+							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210625.shtml">Association internationale des professionnels de l'accessibilité <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m07">Juillet</h3>
+					<ul>
+						<li>
+							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210708.shtml">Loi sur l'accessibilité du Canada - 2 ans d'existence <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20210729.shtml">Semaine internationale du chien d'assistance <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m09">Septembre</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210909.shtml">Semaine internationale des sourds <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m10">Octobre</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211008.shtml">Mois de sensibilisation à l'emploi des personnes handicapées <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211015.shtml">Journée internationale du langage clair <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m11">Novembre</h3>
+					<ul>	
+						<li>
+							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211108.shtml">Langue des signes/ Session COTS <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211122.shtml">Mois de sensibilisation aux handicaps autochtones <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m12">Décembre</h3>
+					<ul>	
+						<li>
+							<a href="https://esdc.prv/fr/dgiit/collectif/nouvelles/2021/20211220.shtml#k1">Section Kudos <i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
 						</li>
 					</ul>
 

--- a/awareness/archived-articles.html
+++ b/awareness/archived-articles.html
@@ -76,21 +76,21 @@
 						
 						<p>It is a small initiative to bring awareness through articles focusing on the importance of various Awareness Days pertaining to Accessibility and their issues. Articles includes upcoming events, training and more. The articles are published in <a href="https://esdc.prv/en/iitb/coporate/news/about.shtml">IITB News</a> under the section: Accessibility Corner.</p>	
 						
-						<h2><a href="#y2021">2021</a></h2>
-						
+						<h2><a href="#y2023">2023</a></h2>
+
 						<ul class="list-unstyled colcount-sm-2 colcount-md-3 colcount-lg-4">
-  							<!-- <li><a href="#m101">January</a></li> -->
-  							<li><a href="#m102">February</a></li>
-  							<!-- <li><a href="#m103">March</a></li> -->
-  							<!-- <li><a href="#m104">April</a></li> -->
-							<li><a href="#m105">May</a></li>
-							<li><a href="#m106">June</a></li>
-							<li><a href="#m107">July</a></li>
-							<!-- <li><a href="#m108">August</a></li> -->
-							<li><a href="#m109">September</a></li>
-							<li><a href="#m110">October</a></li>
-							<li><a href="#m111">November</a></li>
-							<li><a href="#m112">December</a></li>
+							<li><a href="#m301">January</a></li>
+							<li><a href="#m302">February</a></li>
+							<li><a href="#m303">March</a></li>
+							<li><a href="#m304">April</a></li>
+							<li><a href="#m305">May</a></li>
+							<li><a href="#m306">June</a></li>
+							<li><a href="#m307">July</a></li>
+							<!-- <li><a href="#m308">August</a></li> -->
+							<li><a href="#m309">September</a></li>
+							<li><a href="#m310">October</a></li>
+							<li><a href="#m311">November</a></li>
+							<li><a href="#m312">December</a></li>
 						</ul>
 
 						<h2><a href="#y2022">2022</a></h2>
@@ -109,83 +109,123 @@
 							<li><a href="#m211">November</a></li>
 							<li><a href="#m212">December</a></li>
 						</ul>
-					
+
+						<h2><a href="#y2021">2021</a></h2>
+						
+						<ul class="list-unstyled colcount-sm-2 colcount-md-3 colcount-lg-4">
+  							<!-- <li><a href="#m101">January</a></li> -->
+  							<li><a href="#m102">February</a></li>
+  							<!-- <li><a href="#m103">March</a></li> -->
+  							<!-- <li><a href="#m104">April</a></li> -->
+							<li><a href="#m105">May</a></li>
+							<li><a href="#m106">June</a></li>
+							<li><a href="#m107">July</a></li>
+							<!-- <li><a href="#m108">August</a></li> -->
+							<li><a href="#m109">September</a></li>
+							<li><a href="#m110">October</a></li>
+							<li><a href="#m111">November</a></li>
+							<li><a href="#m112">December</a></li>
+						</ul>
 					
 					<p>
 						Articles published for the month of:
 					</p>
 
-					<h2 id="y2021">2021</h2>
-
-					<h3 id="m02">February</h3>
+					
+					<h2 id="y2023">2023</h2>
+					<h3 id="m301">January</h3>
 					<ul>
 						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210225.shtml">International Repetitive Strain Injury Awareness day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/world-braille-day.html">World Braille Day</a>
 						</li>
 					</ul>
 
-					<h3 id="m05">May</h3>
+					<h3 id="m302">February</h3>
 					<ul>
 						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210513.shtml">Global Accessibilty Awareness Day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/world-cancer-day.html">World Cancer Day</a>
 						</li>
 						<li>
-							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210527.shtml">National Accessibility Week<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/rsi-awareness-day.html">Repetitive Strain Injury Day</a>
+						</li>
+					</ul>
+
+					<h3 id="m303">March</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/developmental-disabilities-awareness-month.html">Developmental Disability Awareness Month</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/world-autism-awareness-day.html">World Autism Awareness Day</a>
 						</li>
 					</ul>
 					
-					<h3 id="m06">June</h3>
+					<h3 id="m304">April</h3>
 					<ul>
 						<li>
-							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210625.shtml">International Association of Accessibility Professionals<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/fnd-awareness-day.html">International Functional and Neurological Disorder Awareness Day</a>
 						</li>
 					</ul>
-
-					<h3 id="m07">July</h3>
-					<ul>
-						<li>
-							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210708.shtml">Accessible Canada Act - 2 year Anniversary<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210729.shtml">International Dog Week<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m09">September</h3>
-					<ul>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210909.shtml">International week of the Deaf<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m10">October</h3>
-					<ul>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211008.shtml">Disability Employment Awareness Month<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211015.shtml">International Plain language day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m11">November</h3>
-					<ul>	
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211108.shtml">Sign Language/ COTS Session<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211122.shtml">Indigenous Disability Awareness Month<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m12">December</h3>
-					<ul>	
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211220.shtml">Kudos Section<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
 					
+					<h3 id="m305">May</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/gaad.html">Global Accessibility Awareness Day</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/mci-eod-workplace.html">Mild Cognitive Disorders (MCI) and Early Onset Dementia (EOD)</a>
+						</li>
+					</ul>
+					
+					<h3 id="m306">June</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/naaw.html">National AccessAbility Week</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/creating-an-accessible-outlook-email.html">Creating an Accessible Outlook email</a>
+						</li>
+					</ul>
+
+					<h3 id="m307">July</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/accessibility-tools-and-adaptive-technology-for-neurodiverse-employees.html">Accessibility Tools and Adaptive Technology for Neurodiverse Employees</a>
+						</li>
+					</ul>
+
+					<h3 id="m309">September</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/national-service-dog-month.html">National Service Dog Month</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/accessibility-tools-and-adaptive-technology-for-deaf.html">Accessibility Tools and Adaptive Technology for Deaf, Deafened and/or Hard-of-Hearing Employees</a>
+						</li>
+					</ul>
+
+					<h3 id="m310">October</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/ndeam.html">National Disability Employment Awareness Month</a>
+						</li>
+					</ul>
+
+					<h3 id="m311">November</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/world-sight-day.html">World Sight Day: Enhancing Workplace Accessibility-Tools and Adaptive Technology for Vision-Impaired Employees</a>
+						</li>
+					</ul>
+
+					<h3 id="m312">December</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/colour-contrast-analyzer-tools.html">Making Content Accessible with Colour Contrast Analyzer Tools</a>
+						</li>
+					</ul>
+					
+					<!-- Articles for 2022 -->
 
 					<h2 id="y2022">2022</h2>
 					<h3 id="m201">January</h3>
@@ -276,6 +316,78 @@
 					<ul>
 						<li>
 							<a href="https://esdc.prv/en/iitb/corporate/news/2022/20221212.shtml">Holidays and Accessibility GitHub Awareness Promotion  <i class="fas fa-external-link-square-alt"></i><span class="wb-inv"> Internal link</span></a>
+						</li>
+					</ul>
+
+					<!-- Articles for 2021 -->
+
+					<h2 id="y2021">2021</h2>
+
+					<h3 id="m02">February</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210225.shtml">International Repetitive Strain Injury Awareness day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m05">May</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210513.shtml">Global Accessibilty Awareness Day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210527.shtml">National Accessibility Week<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+					
+					<h3 id="m06">June</h3>
+					<ul>
+						<li>
+							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210625.shtml">International Association of Accessibility Professionals<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m07">July</h3>
+					<ul>
+						<li>
+							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210708.shtml">Accessible Canada Act - 2 year Anniversary<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210729.shtml">International Dog Week<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m09">September</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210909.shtml">International week of the Deaf<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m10">October</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211008.shtml">Disability Employment Awareness Month<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211015.shtml">International Plain language day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m11">November</h3>
+					<ul>	
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211108.shtml">Sign Language/ COTS Session<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211122.shtml">Indigenous Disability Awareness Month<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m12">December</h3>
+					<ul>	
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211220.shtml">Kudos Section<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
 						</li>
 					</ul>
 

--- a/awareness/articles-2024-fr.html
+++ b/awareness/articles-2024-fr.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]>
+<html class="no-js lt-ie9" lang="fr" dir="ltr">
+  <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" lang="fr" dir="ltr">
+  <!--<![endif]-->
+  <head>
+    <meta charset="utf-8">
+    <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+    <title>Articles pour 2024 - Sensibilisation à l'accessibilité - EDSC /
+      Bureau de l'accessibilité des TI</title>
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <!-- Meta data -->
+    <meta name="description"
+      content="Cette page consiste des articles d'accessibilité publiée durant
+      l'année 2024.">
+    <!-- Meta data-->
+    <!-- Load closure template scripts -->
+    <script
+      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+    <script
+      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <!-- Write closure template -->
+    <script src="../scripts/refTop.min.js"></script>
+    <link rel="stylesheet" href="../css/a11y-dark.css">
+  </head>
+  <body vocab="https://schema.org/" typeof="WebPage">
+    <div id="def-top">
+    </div>
+    <!-- Write closure template -->
+    <script>
+        var defTop = document.getElementById("def-top");
+        defTop.outerHTML = wet.builder.appTop({
+            "appName": [{
+                "text": "EDSC / Bureau de l’accessibilité des TI",
+                "href": "../index-fr.html"
+            }],
+           "breadcrumbs" : [{
+                "title": "Accueil",
+                "href" : "../index-fr.html"
+            },{
+                "title": "Sensibilisation à l'accessibilité",
+                "href" : "index-fr.html"
+            },{
+                "title": "Articles pour l'année 2024",
+            }],
+            "lngLinks": [{
+                "lang": "en",
+                "href": "../awareness/articles-2024.html",
+                "text": "English"
+            }],
+            "menuPath": "../ajax/menu-fr.html"
+        });
+      </script>
+    <div class="container">
+      <div class="row">
+        <main role="main" property="mainContentOfPage" class="container">
+          <h1 property="name" id="wb-cont">Articles pour l'année 2024</h1>
+          <div data-wb-ajax='{
+            "url":
+            "https://bati-itao.github.io/ajax/links-esdc-goc-network-fr.html",
+            "type": "replace"
+            }'></div>
+          <div>
+           <p>
+              Il s'agit d'une petite initiative de sensibilisation à travers des articles mettant l'accent sur l'importance des différentes Journées de sensibilisation relatives à l'accessibilité et à leurs enjeux. Les articles incluent des événements à venir, des formations et plus encore.
+           </p>
+          
+          <p>
+            Articles publiés pour le mois de:
+          </p>
+
+          <h2>Janvier</h2>
+					<!--<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>-->
+
+					<h2>Février</h2>
+					<ul>
+						<li>
+							<a href="../awareness/articles/reconciliation-in-action-fr.html">Réconciliation en action - Le programme d'apprentissage en TI pour les peuples autochtones</a>
+						</li>
+					</ul>
+
+					<!--<h2>Mars</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+					
+					<h2>Avril</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+					
+					<h2>Mai</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+					
+					<h2>Juin</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+					<h2>Juillet</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+					<h2>Septembre</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+                    <h2>Octobre</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+					<h2>Novembre</h2>
+					<ul>
+                        <li>
+                            <a href=""></a>
+                        </li>
+					</ul>
+
+                    <h2>Décembre</h2>
+					<ul>
+                        <li>
+                            <a href=""></a>
+                        </li>
+					</ul>-->
+
+          <p>
+            <h2><a href="../awareness/archived-articles-fr.html">Articles Archivés</a></h2>
+          </p>
+          
+        </div>
+
+          <div id="def-preFooter"></div>
+          <script src="../scripts/preFooter.min.js"></script>
+        </main>
+      </div>
+    </div>
+    <div id="def-footer"></div>
+    <script src="../scripts/appFooter-fr.min.js"></script>
+    <script src="../scripts/refFooter.min.js"></script>
+    <script src="../scripts/bati-itao.min.js"></script>
+  </body>
+</html>

--- a/awareness/articles-2024.html
+++ b/awareness/articles-2024.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]>
+<html class="no-js lt-ie9" lang="en" dir="ltr">
+  <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" lang="en" dir="ltr">
+	<!--<![endif]-->
+
+	<head>
+		<meta charset="utf-8" />
+		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+		<title>
+			Articles for 2024 - Accessibility Awareness - EDSC / IT Accessibility office
+		</title>
+		<meta content="width=device-width,initial-scale=1" name="viewport" />
+		<!-- Meta data -->
+		<meta
+			name="description"
+			content="This page consists of accessibility articles published during the year 2024."
+		/>
+		<!-- Meta data-->
+		<!-- Load closure template scripts -->
+		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<!-- Write closure template -->
+		<script src="../scripts/refTop.min.js"></script>
+		<link rel="stylesheet" href="../css/a11y-dark.css" />
+	</head>
+
+	<body vocab="https://schema.org/" typeof="WebPage">
+		<div id="def-top"></div>
+		<!-- Write closure template -->
+		<script>
+			var defTop = document.getElementById("def-top");
+			defTop.outerHTML = wet.builder.appTop({
+				appName: [
+					{
+						text: "ESDC / IT Accessibility office",
+						href: "../index.html",
+					},
+				],
+				breadcrumbs: [
+					{
+						title: "Home",
+						href: "../index.html",
+					},
+					{
+						title: "Accessibility Awareness",
+						href: "index.html",
+					},
+					{
+						title: "Articles for 2024",
+					},
+				],
+				lngLinks: [
+					{
+						lang: "fr",
+						href: "../awareness/articles-2024-fr.html",
+						text: "Français",
+					},
+				],
+				menuPath: "../ajax/menu-en.html",
+			});
+		</script>
+		<div class="container">
+			<div class="row">
+				<main
+					role="main"
+					property="mainContentOfPage"
+					class="container"
+				>
+					<h1 property="name" id="wb-cont">Articles for 2024</h1>
+					<div
+						data-wb-ajax='{
+              "url": "https://bati-itao.github.io/ajax/links-esdc-goc-network-en.html",
+              "type": "replace"
+              }'
+				></div>
+				<div>
+						<p>
+							It is a small initiative to bring awareness through articles
+							focusing on the importance of various Awareness Days pertaining to
+							Accessibility and their issues. Articles include upcoming events,
+							training and more.
+						</p>
+										
+					<p>
+						Articles published for the month of:
+					</p>
+
+					<!--<h2>January</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>-->
+
+					<h2>February</h2>
+					<ul>
+						<li>
+							<a href="../awareness/articles/reconciliation-in-action.html">Reconciliation in Action - The IT Apprenticeship Program for Indigenous Peoples</a>
+						</li>
+					</ul>
+
+					<!--<h2>March</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+					
+					<h2>April</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+					
+					<h2>May</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+					
+					<h2>June</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+					<h2>July</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+					<h2>September</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+					<h2>October</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+					<h2>November</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>
+
+					<h2>December</h2>
+					<ul>
+						<li>
+							<a href=""></a>
+						</li>
+					</ul>-->
+
+					<p>
+						<h2><a href="../awareness/archived-articles.html">Archived Articles</a></h2>
+					</p>
+					
+				</div>
+										
+					<div id="def-preFooter"></div>
+					<script src="../scripts/preFooter.min.js"></script>
+				</main>
+			</div>
+		</div>
+		<div id="def-footer"></div>
+		<script src="../scripts/appFooter.min.js"></script>
+		<script src="../scripts/refFooter.min.js"></script>
+		<script src="../scripts/bati-itao.min.js"></script>
+	</body>
+</html>

--- a/awareness/articles/reconciliation-in-action-fr.html
+++ b/awareness/articles/reconciliation-in-action-fr.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]>
+<html class="no-js lt-ie9" lang="fr" dir="ltr">
+  <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" lang="fr" dir="ltr">
+<!--<![endif]-->
+
+<head>
+    <meta charset="utf-8">
+    <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+    <title>Réconciliation en action - Le programme d'apprentissage en TI pour les peuples autochtones - EDSC / Bureau de l’accessibilité des TI
+    </title>
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <!-- Meta data -->
+    <meta name="description"
+        content="">
+    <!-- Meta data-->
+    <!-- Load closure template scripts -->
+    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <!-- Write closure template -->
+    <script src="../../scripts/refTop.min.js"></script>
+    <link rel="stylesheet" href="../../css/a11y-dark.css">
+</head>
+
+<body vocab="https://schema.org/" typeof="WebPage">
+    <div id="def-top">
+    </div>
+    <!-- Write closure template -->
+    <script>
+        var defTop = document.getElementById("def-top");
+        defTop.outerHTML = wet.builder.appTop({
+            "appName": [{
+                "text": "EDSC / Bureau de l’accessibilité des TI",
+                "href": "../../index-fr.html"
+            }],
+            "breadcrumbs": [{
+                "title": "Accueil",
+                "href": "../../index-fr.html"
+            }, {
+                "title": "Sensibilisation à l'accessibilité",
+                "href": "../index-fr.html"
+            }, {
+                "title": "Réconciliation en action - Le programme d'apprentissage en TI pour les peuples autochtones",
+            }],
+            "lngLinks": [{
+                "lang": "en",
+                "href": "reconciliation-in-action.html",
+                "text": "English"
+            }],
+            "menuPath": "../../ajax/menu-fr.html"
+        });
+    </script>
+    <div class="container">
+        <div class="row">
+            <main role="main" property="mainContentOfPage" class="col-md-9 col-md-push-3">
+                <h1 property="name" id="wb-cont">Réconciliation en action - Le programme d'apprentissage en TI pour les peuples autochtones</h1>
+                <p>On reconnaît de plus en plus l'importance de la diversité, de l'équité et de l'inclusion dans l'industrie technique, et historiquement, les peuples autochtones ont été sous-représentés dans ce domaine. Pour combler cet écart, le gouvernement du Canada a mis en place un programme novateur, <a href="https://talent.canada.ca/en/indigenous-it-apprentice"> Programme d'apprentissage en TI pour les peuples autochtones</a>.</p>
+
+                <h2>Le sais-tu?</h2>
+                <p>Les pratiques d'embauche traditionnelles constituent des obstacles à l'emploi pour les peuples autochtones. Les peuples autochtones représentent près de 5 % de la population active disponible, mais au sein du gouvernement du Canada, ils représentent environ 3 % de la main-d'œuvre en TI. Les femmes autochtones sont encore plus sous-représentées.</p>
+
+                <h2>Une initiative transformatrice</h2>
+                <p>Le Programme d'apprentissage en TI pour les peuples autochtones met l'accent sur la passion et le potentiel d'une personne par rapport aux diplômes d'études formelles. Cette approche nous permet d'attirer des personnes passionnées et talentueuses dans notre main-d'œuvre numérique tout en contribuant à combler les écarts en matière d'éducation, d'emploi et d'économie auxquels sont confrontés les peuples autochtones du Canada.</p>
+                <p>Ce programme est inclusif de par sa conception et reconnaît la valeur de la communauté tout en tenant compte des besoins et des préférences des apprenants autochtones. Il montre comment « faire différent » peut avoir un grand impact sur la vie des gens au niveau personnel, familial, communautaire et régional.</p>
+
+                <h2>Aller de l'avant</h2>
+                <p>Le Programme d'apprentissage en TI pour les peuples autochtones a été lancé en tant que programme pilote de la Direction générale de l'innovation et de la technologie de l'information (DGIST) d'EDSC en 2020 et a été élargi à un programme à l'échelle du gouvernement du Canada en 2022. Joignez-vous à nous dans ce voyage alors que nous continuons à étendre notre portée et notre impact.</p>
+
+                <h2>Pour les recruteurs</h2>
+                <p>Si vous êtes un gestionnaire d'embauche ou un conseiller en dotation responsable de l'embauche pour le poste de TI de premier échelon (IT-01 ou l'équivalent), auprès d'EDSC ou d'un autre ministère, organisme ou société d'État du gouvernement du Canada, veuillez communiquer avec le Bureau des initiatives autochtones à l' adresse suivante : <a href="mailto:EDSC.PATIPA.JUMELAGE.EMPLOIS-ITAPIP.JOB.MATCHING.ESDC@hrsdc-rhdcc.gc.ca">EDSC.PATIPA.JUMELAGE.EMPLOIS-ITAPIP.JOB.MATCHING.ESDC@hrsdc-rhdcc.gc.ca</a>.</p>
+
+
+
+
+            <div id="def-preFooter"></div>
+            <script src="../../scripts/preFooter.min.js"></script>
+            </main>
+            <nav id="wb-sec" class="wb-sec col-md-3 col-md-pull-9" typeof="SiteNavigationElement">
+                <h2 class="wb-inv">Menu de la section</h2>
+                <section class="list-group menu list-unstyled">
+                    <h3 class="wb-navcurr">
+                        Contenu
+                    </h3>
+
+                    <ul class="list-group menu list-unstyled">
+                        <li><a class="list-group-item" href="../../awareness/awareness-days-fr.html">Journée de
+                                sensibilisation</a></li>
+                        <li><a class="list-group-item" href="../../awareness/awareness-days-goc-fr.html">Journée de
+                                sensibilisation du Gouvernement du Canada</a></li>
+                        <li><a class="list-group-item" href="../../awareness/awareness-event-fr.html">Évènements</a></li>
+                        <li><a class="list-group-item" href="../../awareness/training-fr.html">Formations</a></li>
+                        <li><a class="list-group-item" href="../../awareness/articles-2021-fr.html">Articles de l'année
+                                2021</a></li>
+                        <li><a class="list-group-item" href="../../awareness/articles-2022-fr.html">Articles de l'année
+                                2022</a></li>
+                        <li><a class="list-group-item active" href="../../awareness/articles-2023-fr.html">Articles de l'année
+                                2023</a></li>
+                    </ul>
+                </section>
+            </nav>
+        </div>
+    </div>
+    </main>
+    <div id="def-footer"></div>
+    <script src="../../scripts/appFooter-fr.min.js"></script>
+    <script src="../../scripts/refFooter.min.js"></script>
+    <script src="../../scripts/bati-itao.min.js"></script>
+</body>
+
+</html>

--- a/awareness/articles/reconciliation-in-action.html
+++ b/awareness/articles/reconciliation-in-action.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]>
+<html class="no-js lt-ie9" lang="en" dir="ltr">
+  <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" lang="en" dir="ltr">
+<!--<![endif]-->
+
+<head>
+    <meta charset="utf-8">
+    <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+    <title>Reconciliation in Action - The IT Apprenticeship Program for Indigenous Peoples - ESDC / IT Accessibility Office</title>
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <!-- Meta data -->
+    <meta name="description"
+        content="">
+    <!-- Meta data-->
+    <!-- Load closure template scripts -->
+    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <!-- Write closure template -->
+    <script src="../../scripts/refTop.min.js"></script>
+    <link rel="stylesheet" href="../../css/a11y-dark.css">
+</head>
+
+<body vocab="https://schema.org/" typeof="WebPage">
+    <div id="def-top">
+    </div>
+    <!-- Write closure template -->
+    <script>
+        var defTop = document.getElementById("def-top");
+        defTop.outerHTML = wet.builder.appTop({
+            "appName": [{
+                "text": "ESDC / IT Accessibility office",
+                "href": "../../index.html"
+            }],
+            "breadcrumbs": [{
+                "title": "Home",
+                "href": "../../index.html"
+            }, {
+                "title": "Accessibility Awareness",
+                "href": "../index.html"
+            }, {
+                "title": "Reconciliation in Action - The IT Apprenticeship Program for Indigenous Peoples",
+            }],
+            "lngLinks": [{
+                "lang": "fr",
+                "href": "reconciliation-in-action.html",
+                "text": "Français"
+            }],
+            "menuPath": "../../ajax/menu-en.html"
+        });
+    </script>
+    <div class="container">
+        <div class="row">
+            <main role="main" property="mainContentOfPage" class="col-md-9 col-md-push-3">
+                <h1 property="name" id="wb-cont">Reconciliation in Action - The IT Apprenticeship Program for Indigenous Peoples</h1>
+                <p>There has been growing recognition of the importance of diversity, equity, and inclusion in the technical industry, and historically, Indigenous Peoples have been under-represented in this field. To bridge this gap, the Government of Canada introduced an innovative program - <a href="https://talent.canada.ca/en/indigenous-it-apprentice"> IT Apprenticeship Program for Indigenous Peoples</a>.</p>
+
+                <h2>Do you know?</h2>
+                <p>Traditional hiring practices pose barriers to employment for Indigenous peoples. Indigenous peoples represent nearly 5% of the available working population but in the Government of Canada, they represent about 3% of the IT workforce. Indigenous women are even more under-represented.</p>
+
+                <h2>A Transformative Initiative</h2>
+                <p>The IT Apprenticeship Program for Indigenous Peoples places focus on an individual’s passion and potential over formal education credentials. This approach allows us to attract passionate and talented individuals into our digital workforce while contributing to closing the educational, employment, and economic gaps faced by Indigenous Peoples in Canada. </p>
+                <p>This program is inclusive by design and acknowledges the value of the community while considering the needs and preferences of Indigenous learners. It shows how "doing different" can have a big impact on people's lives on a personal, family, community, and regional level.</p>
+
+                <h2>Moving Forward</h2>
+                <p>The IT Apprenticeship Program for Indigenous Peoples was launched as a pilot program in the Innovation, Information Technology Branch (IITB) of ESDC in 2020 and was expanded to a Government of Canada wide program in 2022. Join us in this journey as we continue to expand our reach and impact.</p>
+
+                <h2>For Recruiters</h2>
+                <p>If you are a hiring manager, or staffing advisor who is responsible for hiring for the entry-level IT role (IT-01 or equivalent), with ESDC or another Government of Canada Department, Agency, or Crown corporation please reach out to the Office of Indigenous Initiatives at: <a href="mailto:EDSC.PATIPA.JUMELAGE.EMPLOIS-ITAPIP.JOB.MATCHING.ESDC@hrsdc-rhdcc.gc.ca">EDSC.PATIPA.JUMELAGE.EMPLOIS-ITAPIP.JOB.MATCHING.ESDC@hrsdc-rhdcc.gc.ca</a>.</p>
+        
+        <div id="def-preFooter"></div>
+        <script src="../../scripts/preFooter.min.js"></script>
+        </main>
+        <nav id="wb-sec" class="wb-sec col-md-3 col-md-pull-9" typeof="SiteNavigationElement">
+            <h2 class="wb-inv">Section menu</h2>
+            <section class="list-group menu list-unstyled">
+                <h3 class="wb-navcurr">
+                    Content
+                </h3>
+
+                <ul class="list-group menu list-unstyled">
+                    <li><a class="list-group-item" href="../../awareness/awareness-days.html">Awareness Days</a></li>
+                    <li><a class="list-group-item" href="../../awareness/awareness-days-goc.html">Awareness Days of
+                            Goverment of Canada</a></li>
+                    <li><a class="list-group-item" href="../../awareness/awareness-event.html">Events</a></li>
+                    <li><a class="list-group-item" href="../../awareness/training.html">Training</a></li>
+                    <li><a class="list-group-item" href="../../awareness/articles-2021.html">Articles from 2021</a>
+                    </li>
+                    <li><a class="list-group-item" href="../../awareness/articles-2022.html">Articles from 2022</a>
+                    </li>
+                    <li><a class="list-group-item active" href="../../awareness/articles-2023.html">Articles from 2023</a>
+                    </li>
+                </ul>
+            </section>
+        </nav>
+    </div>
+    </div>
+    <div id="def-footer"></div>
+    <script src="../../scripts/appFooter.min.js"></script>
+    <script src="../../scripts/refFooter.min.js"></script>
+    <script src="../../scripts/bati-itao.min.js"></script>
+</body>
+
+</html>

--- a/awareness/index-fr.html
+++ b/awareness/index-fr.html
@@ -61,7 +61,7 @@
 
                     <section class="col-md-6">
 
-                            <h2 class="h5"><a href="../awareness/articles-2023-fr.html">Articles</a></h2>
+                            <h2 class="h5"><a href="../awareness/articles-2024-fr.html">Articles</a></h2>
 
                             <p>Il s'agit d'une petite initiative
                                 de conscientisation par le biais de d'articles

--- a/awareness/index.html
+++ b/awareness/index.html
@@ -59,7 +59,7 @@
 
                     <section class="col-md-6">
 
-                            <h2 class="h5"><a href="../awareness/articles-2023.html">Articles</a></h2>
+                            <h2 class="h5"><a href="../awareness/articles-2024.html">Articles</a></h2>
 
                             <p>It is a small initiative to bring
                                 awareness through articles focusing on the

--- a/awareness/past-articles.html
+++ b/awareness/past-articles.html
@@ -10,8 +10,7 @@
 		<meta charset="utf-8" />
 		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 		<title>
-			Articles from previous years - Accessibility Awareness - EDSC / Bureau de
-			l'accessibilité des TI
+			Articles from previous years - Accessibility Awareness - EDSC / Bureau de l'accessibilité des TI
 		</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport" />
 		<!-- Meta data -->
@@ -81,21 +80,21 @@
 						
 						<p>It is a small initiative to bring awareness through articles focusing on the importance of various Awareness Days pertaining to Accessibility and their issues. Articles includes upcoming events, training and more. The articles are published in <a href="https://esdc.prv/en/iitb/coporate/news/about.shtml">IITB News</a> under the section: Accessibility Corner.</p>	
 						
-						<h2><a href="#y2021">2021</a></h2>
-						
+						<h2><a href="#y2023">2023</a></h2>
+
 						<ul class="list-unstyled colcount-sm-2 colcount-md-3 colcount-lg-4">
-  							<!-- <li><a href="#m101">January</a></li> -->
-  							<li><a href="#m102">February</a></li>
-  							<!-- <li><a href="#m103">March</a></li> -->
-  							<!-- <li><a href="#m104">April</a></li> -->
-							<li><a href="#m105">May</a></li>
-							<li><a href="#m106">June</a></li>
-							<li><a href="#m107">July</a></li>
-							<!-- <li><a href="#m108">August</a></li> -->
-							<li><a href="#m109">September</a></li>
-							<li><a href="#m110">October</a></li>
-							<li><a href="#m111">November</a></li>
-							<li><a href="#m112">December</a></li>
+							<li><a href="#m301">January</a></li>
+							<li><a href="#m302">February</a></li>
+							<li><a href="#m303">March</a></li>
+							<li><a href="#m304">April</a></li>
+							<li><a href="#m305">May</a></li>
+							<li><a href="#m306">June</a></li>
+							<li><a href="#m307">July</a></li>
+							<!-- <li><a href="#m308">August</a></li> -->
+							<li><a href="#m309">September</a></li>
+							<li><a href="#m310">October</a></li>
+							<li><a href="#m311">November</a></li>
+							<li><a href="#m312">December</a></li>
 						</ul>
 
 						<h2><a href="#y2022">2022</a></h2>
@@ -114,86 +113,123 @@
 							<li><a href="#m211">November</a></li>
 							<li><a href="#m212">December</a></li>
 						</ul>
+
+						<h2><a href="#y2021">2021</a></h2>
+						
+						<ul class="list-unstyled colcount-sm-2 colcount-md-3 colcount-lg-4">
+  							<!-- <li><a href="#m101">January</a></li> -->
+  							<li><a href="#m102">February</a></li>
+  							<!-- <li><a href="#m103">March</a></li> -->
+  							<!-- <li><a href="#m104">April</a></li> -->
+							<li><a href="#m105">May</a></li>
+							<li><a href="#m106">June</a></li>
+							<li><a href="#m107">July</a></li>
+							<!-- <li><a href="#m108">August</a></li> -->
+							<li><a href="#m109">September</a></li>
+							<li><a href="#m110">October</a></li>
+							<li><a href="#m111">November</a></li>
+							<li><a href="#m112">December</a></li>
+						</ul>
 					
 					
 					<p>
 						Articles published for the month of:
 					</p>
 
-					<h2 id="y2021">2021</h2>
-
-					<h3 id="m02">February</h3>
+					
+					<h2 id="y2023">2023</h2>
+					<h3 id="m301">January</h3>
 					<ul>
 						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210225.shtml">International Repetitive Strain Injury Awareness day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/world-braille-day.html">World Braille Day</a>
 						</li>
 					</ul>
 
-					<h3 id="m05">May</h3>
+					<h3 id="m302">February</h3>
 					<ul>
 						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210513.shtml">Global Accessibilty Awareness Day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/world-cancer-day.html">World Cancer Day</a>
 						</li>
 						<li>
-							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210527.shtml">National Accessibility Week<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/rsi-awareness-day.html">Repetitive Strain Injury Day</a>
+						</li>
+					</ul>
+
+					<h3 id="m303">March</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/developmental-disabilities-awareness-month.html">Developmental Disability Awareness Month</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/world-autism-awareness-day.html">World Autism Awareness Day</a>
 						</li>
 					</ul>
 					
-					<h3 id="m06">June</h3>
+					<h3 id="m304">April</h3>
 					<ul>
 						<li>
-							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210625.shtml">International Association of Accessibility Professionals<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+							<a href="../awareness/articles/fnd-awareness-day.html">International Functional and Neurological Disorder Awareness Day</a>
 						</li>
 					</ul>
-
-					<h3 id="m07">July</h3>
-					<ul>
-						<li>
-							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210708.shtml">Accessible Canada Act - 2 year Anniversary<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210729.shtml">International Dog Week<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m09">September</h3>
-					<ul>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210909.shtml">International week of the Deaf<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m10">October</h3>
-					<ul>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211008.shtml">Disability Employment Awareness Month<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211015.shtml">International Plain language day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m11">November</h3>
-					<ul>	
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211108.shtml">Sign Language/ COTS Session<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211122.shtml">Indigenous Disability Awareness Month<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211122.shtml">International day of people with Disabilities<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
-					<h3 id="m12">December</h3>
-					<ul>	
-						<li>
-							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211220.shtml">Kudos Section<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
-						</li>
-					</ul>
-
 					
+					<h3 id="m305">May</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/gaad.html">Global Accessibility Awareness Day</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/mci-eod-workplace.html">Mild Cognitive Disorders (MCI) and Early Onset Dementia (EOD)</a>
+						</li>
+					</ul>
+					
+					<h3 id="m306">June</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/naaw.html">National AccessAbility Week</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/creating-an-accessible-outlook-email.html">Creating an Accessible Outlook email</a>
+						</li>
+					</ul>
+
+					<h3 id="m307">July</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/accessibility-tools-and-adaptive-technology-for-neurodiverse-employees.html">Accessibility Tools and Adaptive Technology for Neurodiverse Employees</a>
+						</li>
+					</ul>
+
+					<h3 id="m309">September</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/national-service-dog-month.html">National Service Dog Month</a>
+						</li>
+						<li>
+							<a href="../awareness/articles/accessibility-tools-and-adaptive-technology-for-deaf.html">Accessibility Tools and Adaptive Technology for Deaf, Deafened and/or Hard-of-Hearing Employees</a>
+						</li>
+					</ul>
+
+					<h3 id="m310">October</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/ndeam.html">National Disability Employment Awareness Month</a>
+						</li>
+					</ul>
+
+					<h3 id="m311">November</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/world-sight-day.html">World Sight Day: Enhancing Workplace Accessibility-Tools and Adaptive Technology for Vision-Impaired Employees</a>
+						</li>
+					</ul>
+
+					<h3 id="m312">December</h3>
+					<ul>
+						<li>
+							<a href="../awareness/articles/colour-contrast-analyzer-tools.html">Making Content Accessible with Colour Contrast Analyzer Tools</a>
+						</li>
+					</ul>
+
 
 					<h2 id="y2022">2022</h2>
 					<h3 id="m201">January</h3>
@@ -284,6 +320,79 @@
 					<ul>
 						<li>
 							<a href="https://esdc.prv/en/iitb/corporate/news/2022/20221212.shtml">Holidays and Accessibility GitHub Awareness Promotion  <i class="fas fa-external-link-square-alt"></i><span class="wb-inv"> Internal link</span></a>
+						</li>
+					</ul>
+
+					<h2 id="y2021">2021</h2>
+
+					<h3 id="m02">February</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210225.shtml">International Repetitive Strain Injury Awareness day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m05">May</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210513.shtml">Global Accessibilty Awareness Day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210527.shtml">National Accessibility Week<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+					
+					<h3 id="m06">June</h3>
+					<ul>
+						<li>
+							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210625.shtml">International Association of Accessibility Professionals<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m07">July</h3>
+					<ul>
+						<li>
+							<a href="https://esdc.prv/en/iitb/corporate/news/2021/20210708.shtml">Accessible Canada Act - 2 year Anniversary<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210729.shtml">International Dog Week<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m09">September</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20210909.shtml">International week of the Deaf<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m10">October</h3>
+					<ul>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211008.shtml">Disability Employment Awareness Month<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211015.shtml">International Plain language day<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m11">November</h3>
+					<ul>	
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211108.shtml">Sign Language/ COTS Session<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211122.shtml">Indigenous Disability Awareness Month<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211122.shtml">International day of people with Disabilities<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
+						</li>
+					</ul>
+
+					<h3 id="m12">December</h3>
+					<ul>	
+						<li>
+							<a href="http://esdc.prv/en/iitb/corporate/news/2021/20211220.shtml">Kudos Section<i class="fas fa-external-link-square-alt"></i><span class="wb-inv">Internal link</span></a>
 						</li>
 					</ul>
 


### PR DESCRIPTION
Here is a list of the elements that I changed [All change did in both languages]:
Added page: articles-2024.html
Added page: reconciliation-in-action.html
Modified index.html: changed the link to the new 2024 article page
Modified archived-articles.html: changed the order of the years to put 2023 on top, 2023 added
Modified past-articles.html: changed the order of the years to put 2023 on top, 2023 added [Noted issue: this seems to be an unnecessary copy of archived-artciles.html, and no French equivalent exist]