### PR TITLE
Fix typo in figcaption.html

### DIFF
--- a/learning/esdc-self-paced-web-accessibility-course/module5/figcaption.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/figcaption.html
@@ -67,16 +67,16 @@
 							<summary class="bg-info">Table of contents</summary>
 							<ul>
 						<li>
-							<a href="../module5/figcaption.html#designing">Designing with figure and figcation</a>
+							<a href="../module5/figcaption.html#designing">Designing with figure and figcaption</a>
 						</li>
 						<li>
-							<a href="../module5/figcaption.html#example">Good example: Figure and figcation</a>
+							<a href="../module5/figcaption.html#example">Good example: Figure and figcaption</a>
 						</li>
 					</ul>
 						</details>
 					</nav>
 	<section>
-		<h2 id="designing">Designing with figure and figcation</h2>
+		<h2 id="designing">Designing with figure and figcaption</h2>
 		<p>The HTML <code>&lt;figure&gt;</code> element can contain a variety of content, including images, illustrations, diagrams, tables and charts. It can also contain videos, quotes, poems and code snippets. It can be accompanied by an optional <code>&lt;figcaption&gt;</code> element.</p>
 		
 		<p>The <code>&lt;figcaption&gt;</code> element represents a visible caption for the figure. It is optional and not required to be in every <code>&lt;figure&gt;</code> element.</p>

--- a/resources/accessible-software-en.html
+++ b/resources/accessible-software-en.html
@@ -49,7 +49,7 @@
         <h1 property="name" id="wb-cont">Accessible Desktop Software</h1>
        <p>Commercial off the shelf (COTS) software are ready-made and available for purchase in the commercial market and they must be accessible for people with disabilities to perform their daily tasks.</p>
        <ul>
-         <li><a href="https://www.microsoft.com/en-ca/windows/accessibility-features">Windows Accessibility</a></li>
+         <li><a href="https://www.microsoft.com/en-ca/Accessibility/windows?SilentAuth=1&activetab=pivot_1%3aprimaryr2">Windows Accessibility</a></li>
        </ul>
 
        <p>You can verify if a software is accessible with the help of the <a href="https://bati-itao.github.io/resources/a11ycheck-nonweb-en.html">Accessibility Compliance Assessments checklist</a></p>

--- a/resources/accessible-software-en.html
+++ b/resources/accessible-software-en.html
@@ -49,7 +49,7 @@
         <h1 property="name" id="wb-cont">Accessible Desktop Software</h1>
        <p>Commercial off the shelf (COTS) software are ready-made and available for purchase in the commercial market and they must be accessible for people with disabilities to perform their daily tasks.</p>
        <ul>
-         <li><a href="https://www.microsoft.com/en-ca/Accessibility/windows?SilentAuth=1&activetab=pivot_1%3aprimaryr2">Windows Accessibility</a></li>
+         <li><a href="https://www.microsoft.com/en-ca/windows/accessibility-features">Windows Accessibility</a></li>
        </ul>
 
        <p>You can verify if a software is accessible with the help of the <a href="https://bati-itao.github.io/resources/a11ycheck-nonweb-en.html">Accessibility Compliance Assessments checklist</a></p>


### PR DESCRIPTION
`<figcaption>` (with a p) is the correct way to write the HTML tag.

Closes #1425