### PR TITLE
Massive CSS fix to the ITAO Github site

### DIFF
--- a/WCAG_temp/index.html
+++ b/WCAG_temp/index.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/_template-en.html
+++ b/_template-en.html
@@ -13,8 +13,8 @@
         content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/_template-fr.html
+++ b/_template-fr.html
@@ -13,8 +13,8 @@
         content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieu du travail.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/awareness/archived-articles-fr.html
+++ b/awareness/archived-articles-fr.html
@@ -18,9 +18,9 @@
     <!-- Meta data-->
     <!-- Load closure template scripts -->
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/archived-articles.html
+++ b/awareness/archived-articles.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/archived-training-fr.html
+++ b/awareness/archived-training-fr.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/archived-training.html
+++ b/awareness/archived-training.html
@@ -15,8 +15,8 @@
         content="This page consists of different training organized by different organizers.">
       <!-- Meta data-->
       <!-- Load closure template scripts -->
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
       <!-- Write closure template -->
       <script src="../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/articles-2021-fr.html
+++ b/awareness/articles-2021-fr.html
@@ -18,9 +18,9 @@
     <!-- Meta data-->
     <!-- Load closure template scripts -->
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/articles-2021.html
+++ b/awareness/articles-2021.html
@@ -15,8 +15,8 @@
         content="This page consists of accessibility articles published during the year 2021.">
       <!-- Meta data-->
       <!-- Load closure template scripts -->
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
       <!-- Write closure template -->
       <script src="../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/articles-2022-fr.html
+++ b/awareness/articles-2022-fr.html
@@ -18,9 +18,9 @@
     <!-- Meta data-->
     <!-- Load closure template scripts -->
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/articles-2022.html
+++ b/awareness/articles-2022.html
@@ -15,8 +15,8 @@
         content="This page consists of accessibility articles published during the year 2022.">
       <!-- Meta data-->
       <!-- Load closure template scripts -->
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
       <!-- Write closure template -->
       <script src="../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/articles-2023-fr.html
+++ b/awareness/articles-2023-fr.html
@@ -18,9 +18,9 @@
     <!-- Meta data-->
     <!-- Load closure template scripts -->
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/articles-2023.html
+++ b/awareness/articles-2023.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/articles-2024-fr.html
+++ b/awareness/articles-2024-fr.html
@@ -18,9 +18,9 @@
     <!-- Meta data-->
     <!-- Load closure template scripts -->
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
     <script
-      src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/articles-2024.html
+++ b/awareness/articles-2024.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/articles/IRCC-ACE-fr.html
+++ b/awareness/articles/IRCC-ACE-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/IRCC-ACE.html
+++ b/awareness/articles/IRCC-ACE.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/NDEAM-fr.html
+++ b/awareness/articles/NDEAM-fr.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/NDEAM.html
+++ b/awareness/articles/NDEAM.html
@@ -16,8 +16,8 @@
         content="This page is about National Disability Employment Awareness Month">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/accessibility-awareness-day-2024-fr.html
+++ b/awareness/articles/accessibility-awareness-day-2024-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/accessibility-awareness-day-2024.html
+++ b/awareness/articles/accessibility-awareness-day-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/accessibility-tools-and-adaptive-technology-for-deaf-fr.html
+++ b/awareness/articles/accessibility-tools-and-adaptive-technology-for-deaf-fr.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/accessibility-tools-and-adaptive-technology-for-deaf.html
+++ b/awareness/articles/accessibility-tools-and-adaptive-technology-for-deaf.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/accessibility-tools-and-adaptive-technology-for-neurodiverse-employees-fr.html
+++ b/awareness/articles/accessibility-tools-and-adaptive-technology-for-neurodiverse-employees-fr.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/accessibility-tools-and-adaptive-technology-for-neurodiverse-employees.html
+++ b/awareness/articles/accessibility-tools-and-adaptive-technology-for-neurodiverse-employees.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/accessible-and-inclusive-meetings-2024-fr.html
+++ b/awareness/articles/accessible-and-inclusive-meetings-2024-fr.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/accessible-and-inclusive-meetings-2024.html
+++ b/awareness/articles/accessible-and-inclusive-meetings-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/beyond-accessibility-fr.html
+++ b/awareness/articles/beyond-accessibility-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/beyond-accessibility.html
+++ b/awareness/articles/beyond-accessibility.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/collective-responsability-fr.html
+++ b/awareness/articles/collective-responsability-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/collective-responsability.html
+++ b/awareness/articles/collective-responsability.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/colour-blind-awareness-day-2024-fr.html
+++ b/awareness/articles/colour-blind-awareness-day-2024-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/colour-blind-awareness-day-2024.html
+++ b/awareness/articles/colour-blind-awareness-day-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/colour-contrast-analyzer-tools-fr.html
+++ b/awareness/articles/colour-contrast-analyzer-tools-fr.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/colour-contrast-analyzer-tools.html
+++ b/awareness/articles/colour-contrast-analyzer-tools.html
@@ -16,8 +16,8 @@
         content="This page is about Making Content Accessible with Colour Contrast Analyzer Tools">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/creating-an-accessible-outlook-email-fr.html
+++ b/awareness/articles/creating-an-accessible-outlook-email-fr.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/creating-an-accessible-outlook-email.html
+++ b/awareness/articles/creating-an-accessible-outlook-email.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/developmental-disabilities-awareness-month-fr.html
+++ b/awareness/articles/developmental-disabilities-awareness-month-fr.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/developmental-disabilities-awareness-month.html
+++ b/awareness/articles/developmental-disabilities-awareness-month.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/fnd-awareness-day-fr.html
+++ b/awareness/articles/fnd-awareness-day-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/fnd-awareness-day.html
+++ b/awareness/articles/fnd-awareness-day.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/functional-neurological-disorder-awareness-month-2024-fr.html
+++ b/awareness/articles/functional-neurological-disorder-awareness-month-2024-fr.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/functional-neurological-disorder-awareness-month-2024.html
+++ b/awareness/articles/functional-neurological-disorder-awareness-month-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/gaad-fr.html
+++ b/awareness/articles/gaad-fr.html
@@ -17,8 +17,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/gaad.html
+++ b/awareness/articles/gaad.html
@@ -16,8 +16,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/holiday-2024-fr.html
+++ b/awareness/articles/holiday-2024-fr.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/holiday-2024.html
+++ b/awareness/articles/holiday-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/intro-to-WCAG-2024-fr.html
+++ b/awareness/articles/intro-to-WCAG-2024-fr.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/intro-to-WCAG-2024.html
+++ b/awareness/articles/intro-to-WCAG-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/mci-eod-workplace-fr.html
+++ b/awareness/articles/mci-eod-workplace-fr.html
@@ -17,8 +17,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/mci-eod-workplace.html
+++ b/awareness/articles/mci-eod-workplace.html
@@ -16,8 +16,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/naaw-fr.html
+++ b/awareness/articles/naaw-fr.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/naaw.html
+++ b/awareness/articles/naaw.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/national-AccessAbility-week-2024-fr.html
+++ b/awareness/articles/national-AccessAbility-week-2024-fr.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/national-AccessAbility-week-2024.html
+++ b/awareness/articles/national-AccessAbility-week-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/national-service-dog-month-fr.html
+++ b/awareness/articles/national-service-dog-month-fr.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/national-service-dog-month.html
+++ b/awareness/articles/national-service-dog-month.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/reconciliation-in-action-fr.html
+++ b/awareness/articles/reconciliation-in-action-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/reconciliation-in-action.html
+++ b/awareness/articles/reconciliation-in-action.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/reveal-or-conceal-disclosing-disability-2024-fr.html
+++ b/awareness/articles/reveal-or-conceal-disclosing-disability-2024-fr.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/reveal-or-conceal-disclosing-disability-2024.html
+++ b/awareness/articles/reveal-or-conceal-disclosing-disability-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/rmt-update-fra.html
+++ b/awareness/articles/rmt-update-fra.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/rmt-update.html
+++ b/awareness/articles/rmt-update.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/rsi-awareness-day-fr.html
+++ b/awareness/articles/rsi-awareness-day-fr.html
@@ -18,8 +18,8 @@
 		<meta name="description" content="" />
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/rsi-awareness-day.html
+++ b/awareness/articles/rsi-awareness-day.html
@@ -18,8 +18,8 @@
 		<meta name="description" content="" />
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/start-with-accessibility-fr.html
+++ b/awareness/articles/start-with-accessibility-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/start-with-accessibility.html
+++ b/awareness/articles/start-with-accessibility.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/understanding-neurodiversity-fr.html
+++ b/awareness/articles/understanding-neurodiversity-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/understanding-neurodiversity.html
+++ b/awareness/articles/understanding-neurodiversity.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/world-autism-awareness-day-fr.html
+++ b/awareness/articles/world-autism-awareness-day-fr.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/world-autism-awareness-day.html
+++ b/awareness/articles/world-autism-awareness-day.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/world-braille-day-fr.html
+++ b/awareness/articles/world-braille-day-fr.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/world-braille-day.html
+++ b/awareness/articles/world-braille-day.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/world-cancer-day-2024-fr.html
+++ b/awareness/articles/world-cancer-day-2024-fr.html
@@ -17,8 +17,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/world-cancer-day-2024.html
+++ b/awareness/articles/world-cancer-day-2024.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/articles/world-cancer-day-fr.html
+++ b/awareness/articles/world-cancer-day-fr.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/world-cancer-day.html
+++ b/awareness/articles/world-cancer-day.html
@@ -14,8 +14,8 @@
 		<meta name="description" content="This page is about World Cancer Day" />
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/articles/world-sight-day-fr.html
+++ b/awareness/articles/world-sight-day-fr.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/a11y-dark.css" />

--- a/awareness/articles/world-sight-day.html
+++ b/awareness/articles/world-sight-day.html
@@ -16,8 +16,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../css/a11y-dark.css">

--- a/awareness/awareness-days-fr.html
+++ b/awareness/awareness-days-fr.html
@@ -15,8 +15,8 @@
         content="Cette page consiste des différentes journées de sensibilisations qui arrivent au courant de l'année.">
       <!-- Meta data-->
       <!-- Load closure template scripts -->
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
       <!-- Write closure template -->
       <script src="../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/awareness-days-goc-fr.html
+++ b/awareness/awareness-days-goc-fr.html
@@ -15,8 +15,8 @@
         content="Cette page consiste des différentes journées de sensibilisations qui arrivent au courant de l'année au gouvernement du Canada.">
       <!-- Meta data-->
       <!-- Load closure template scripts -->
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
       <!-- Write closure template -->
       <script src="../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/awareness-days-goc.html
+++ b/awareness/awareness-days-goc.html
@@ -15,8 +15,8 @@
         content="This page consists of the various awareness days that occur throughout the year in the Government of Canada.">
       <!-- Meta data-->
       <!-- Load closure template scripts -->
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
       <!-- Write closure template -->
       <script src="../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/awareness-days.html
+++ b/awareness/awareness-days.html
@@ -15,8 +15,8 @@
         content="This page consists of the different awareness days that happen throughout the year.">
       <!-- Meta data-->
       <!-- Load closure template scripts -->
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
       <!-- Write closure template -->
       <script src="../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/awareness-event-fr.html
+++ b/awareness/awareness-event-fr.html
@@ -15,8 +15,8 @@
         content="Cette page consiste d'évènements organisés par différents organisateurs.">
       <!-- Meta data-->
       <!-- Load closure template scripts -->
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
       <!-- Write closure template -->
       <script src="../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/awareness-event.html
+++ b/awareness/awareness-event.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/events-fr.html
+++ b/awareness/events-fr.html
@@ -14,9 +14,9 @@
         <!-- Meta data-->
         <!-- Load closure template scripts -->
         <script
-            src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+            src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
         <script
-            src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+            src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
         <!-- Write closure template -->
         <script src="../scripts/refTop.min.js"></script>
         <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/index-fr.html
+++ b/awareness/index-fr.html
@@ -16,9 +16,9 @@
         <!-- Meta data-->
         <!-- Load closure template scripts -->
         <script
-            src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+            src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
         <script
-            src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+            src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
         <!-- Write closure template -->
         <script src="../scripts/refTop.min.js"></script>
         <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/index.html
+++ b/awareness/index.html
@@ -15,9 +15,9 @@
         <!-- Meta data-->
         <!-- Load closure template scripts -->
         <script
-            src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+            src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
         <script
-            src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+            src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
         <!-- Write closure template -->
         <script src="../scripts/refTop.min.js"></script>
         <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/past-articles.html
+++ b/awareness/past-articles.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/past-events-fr.html
+++ b/awareness/past-events-fr.html
@@ -16,9 +16,9 @@
         <!-- Meta data-->
         <!-- Load closure template scripts -->
         <script
-            src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+            src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
         <script
-            src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+            src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
         <!-- Write closure template -->
         <script src="../scripts/refTop.min.js"></script>
         <link rel="stylesheet" href="../css/a11y-dark.css">

--- a/awareness/past-events.html
+++ b/awareness/past-events.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/training-2.html
+++ b/awareness/training-2.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/training-fr.html
+++ b/awareness/training-fr.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/training.html
+++ b/awareness/training.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/upcoming-events-fr.html
+++ b/awareness/upcoming-events-fr.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/awareness/upcoming-events.html
+++ b/awareness/upcoming-events.html
@@ -19,8 +19,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../css/a11y-dark.css" />

--- a/cra/index.html
+++ b/cra/index.html
@@ -13,8 +13,8 @@
         content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/dashboard/index-fr.html
+++ b/dashboard/index-fr.html
@@ -15,8 +15,8 @@
     <!-- Meta data-->
     <link rel="stylesheet" href="./styles/styles.css">
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -15,8 +15,8 @@
     <!-- Meta data-->
     <link rel="stylesheet" href="./styles/styles.css">
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/learning/_template-en.html
+++ b/learning/_template-en.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/learning/_template-fr.html
+++ b/learning/_template-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaches/demo-site/faq-fr.html
+++ b/learning/coaches/demo-site/faq-fr.html
@@ -4,9 +4,9 @@
 		<title>Accueil - Green Tech</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">	
 		<!--
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<script src="../../../scripts/refTop.min.js"></script>
 		-->
 		 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/learning/coaches/demo-site/faq.html
+++ b/learning/coaches/demo-site/faq.html
@@ -4,9 +4,9 @@
 		<title>FAQ - Green Tech</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">	
 		<!--
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<script src="../../../scripts/refTop.min.js"></script>
 		-->
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/learning/coaches/demo-site/submit-ticket-fr.html
+++ b/learning/coaches/demo-site/submit-ticket-fr.html
@@ -4,9 +4,9 @@
 		<title>Soumettre un ticket - Green Tech</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">	
 		<!--
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<script src="../../../scripts/refTop.min.js"></script>
 		-->
 		 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/learning/coaches/demo-site/submit-ticket-skip-fr.html
+++ b/learning/coaches/demo-site/submit-ticket-skip-fr.html
@@ -4,9 +4,9 @@
 		<title>Soumettre un ticket - Green Tech</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">	
 		<!--
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<script src="../../../scripts/refTop.min.js"></script>
 		-->
 		 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/learning/coaches/demo-site/submit-ticket-skip.html
+++ b/learning/coaches/demo-site/submit-ticket-skip.html
@@ -4,9 +4,9 @@
 		<title>Submit a ticket - Green Tech</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">	
 		<!--
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<script src="../../../scripts/refTop.min.js"></script>
 		-->
 		 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/learning/coaches/demo-site/submit-ticket.html
+++ b/learning/coaches/demo-site/submit-ticket.html
@@ -4,9 +4,9 @@
 		<title>Submit a ticket - Green Tech</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">	
 		<!--
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<script src="../../../scripts/refTop.min.js"></script>
 		-->
 		 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/learning/coaching/accessibility-en.html
+++ b/learning/coaching/accessibility-en.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/accessibility-fr.html
+++ b/learning/coaching/accessibility-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/feedback-en.html
+++ b/learning/coaching/feedback-en.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/feedback-fr.html
+++ b/learning/coaching/feedback-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/index-fr.html
+++ b/learning/coaching/index-fr.html
@@ -13,8 +13,8 @@
         content="EDSC s'engage à assurer l'accessibilité de son site web et de ses ressources bureautiques. Ces sessions d'entraînement présentent les normes et les directives fédérales en matière d'accessibilité et mettent l'accent sur les exigences, les rôles et les responsabilités liés au respect de ces normes.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/index.html
+++ b/learning/coaching/index.html
@@ -13,8 +13,8 @@
         content="ESDC is committed to ensuring the accessibility of its websites and desktop assets are meeting Canadian standards. These coaching sessions outline federal standards and guidelines on accessibility and emphasizes the requirements, roles and responsibilities involved in compliance with these standards.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/quiz-en.html
+++ b/learning/coaching/quiz-en.html
@@ -12,8 +12,8 @@
     <meta name="description" content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities" />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/quiz-fr.html
+++ b/learning/coaching/quiz-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/session-references-en.html
+++ b/learning/coaching/session-references-en.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/session-references-fr.html
+++ b/learning/coaching/session-references-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/software-en.html
+++ b/learning/coaching/software-en.html
@@ -15,8 +15,8 @@
             content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../scripts/refTop.min.js"></script>
       </head>

--- a/learning/coaching/software-fr.html
+++ b/learning/coaching/software-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/thankyou-en.html
+++ b/learning/coaching/thankyou-en.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/coaching/thankyou-fr.html
+++ b/learning/coaching/thankyou-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/desktop-application-developer-en.html
+++ b/learning/curriculum/desktop-application-developer-en.html
@@ -13,8 +13,8 @@
 		content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/desktop-application-developer-fr.html
+++ b/learning/curriculum/desktop-application-developer-fr.html
@@ -14,8 +14,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/desktop-application-tester-en.html
+++ b/learning/curriculum/desktop-application-tester-en.html
@@ -13,8 +13,8 @@
 		content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/desktop-application-tester-fr.html
+++ b/learning/curriculum/desktop-application-tester-fr.html
@@ -14,8 +14,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/general-accessibility-en.html
+++ b/learning/curriculum/general-accessibility-en.html
@@ -13,8 +13,8 @@
 		content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/general-accessibility-fr.html
+++ b/learning/curriculum/general-accessibility-fr.html
@@ -14,8 +14,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/index-fr.html
+++ b/learning/curriculum/index-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/index.html
+++ b/learning/curriculum/index.html
@@ -13,8 +13,8 @@
 		content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/web-application-developer-en.html
+++ b/learning/curriculum/web-application-developer-en.html
@@ -13,8 +13,8 @@
 		content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/web-application-developer-fr.html
+++ b/learning/curriculum/web-application-developer-fr.html
@@ -14,8 +14,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/web-application-tester-en.html
+++ b/learning/curriculum/web-application-tester-en.html
@@ -13,8 +13,8 @@
 		content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/web-application-tester-fr.html
+++ b/learning/curriculum/web-application-tester-fr.html
@@ -14,8 +14,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/writers-editors-translators-en.html
+++ b/learning/curriculum/writers-editors-translators-en.html
@@ -13,8 +13,8 @@
 		content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/curriculum/writers-editors-translators-fr.html
+++ b/learning/curriculum/writers-editors-translators-fr.html
@@ -14,8 +14,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/esdc-self-paced-web-accessibility-course/best-practice/all-best-practice-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/best-practice/all-best-practice-fr.html
@@ -10,8 +10,8 @@
     <!-- Meta data-->
     <!-- Load closure template scripts -->
     <script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../../css/a11y-dark.css" />

--- a/learning/esdc-self-paced-web-accessibility-course/best-practice/all-best-practice.html
+++ b/learning/esdc-self-paced-web-accessibility-course/best-practice/all-best-practice.html
@@ -10,8 +10,8 @@
     <!-- Meta data-->
     <!-- Load closure template scripts -->
     <script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../../css/a11y-dark.css" />

--- a/learning/esdc-self-paced-web-accessibility-course/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/index-fr.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/esdc-self-paced-web-accessibility-course/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/index.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_01.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_01.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_02.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_02.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_03.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_03.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_04.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_04.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_05.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_05.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_06.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_06.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_07.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_07.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_08.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_08.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_09.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_09.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_10.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_10.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/a_11.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/a_11.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/best-practice.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/best-practice.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/index.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module0/test.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module0/test.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module1/accessibility-guidelines-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/accessibility-guidelines-fr.html
@@ -11,8 +11,8 @@
 		content="Décrit les Règles pour l'accessibilité des contenus Web (WCAG) , les Règles d’accessibilité pour les outils d’édition (ATAG) et les applications Internet riches et accessibles (ARIA).">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module1/accessibility-guidelines.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/accessibility-guidelines.html
@@ -11,8 +11,8 @@
 		content="Describes the Web Content Accessibility Guidelines (WCAG), the Authoring Tool Accessibility Guidelines (ATAG) and Accessible Rich Internet Applications (WAI-ARIA).">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module1/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/index-fr.html
@@ -10,8 +10,8 @@
 		content="Ce module présente l’accessibilité du Web, les types d’incapacités et les lignes directrices sur l’accessibilité, y compris les Règles pour l'accessibilité des contenus Web (WCAG) , les Règles d’accessibilité pour les outils d’édition (ATAG) et les applications Internet riches et accessibles (ARIA).">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module1/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/index.html
@@ -10,8 +10,8 @@
 		content="This module introduces web accessibility, disability types and accessibility guidelines including Web Content Accessibility Guidelines (WCAG), Authoring Tool Accessibility Guidelines (ATAG), and Accessible Rich Internet Application (ARIA).">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module1/laws-and-government-standards-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/laws-and-government-standards-fr.html
@@ -10,8 +10,8 @@
 		content="Décrit la Loi canadienne sur l’accessibilité, la Norme sur l’accessibilité des sites Web du gouvernement du Canada et la Norme européenne pour l’accessibilité numérique, EN 301 549.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module1/laws-and-government-standards.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/laws-and-government-standards.html
@@ -10,8 +10,8 @@
 		content="Describes the Accessible Canada Act (ACA), the Government of Canada Web Accessibility Standard, and the European Accessibility Standard EN 301 549.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module1/types-of-disabilities-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/types-of-disabilities-fr.html
@@ -10,8 +10,8 @@
 		content="Définit les types d’incapacités et les considérations de conception connexes. Couvre la cécité, la malvoyance, le daltonisme, le handicap auditif, la surdicécité, les déficiences motrices, les déficiences de lecture et les troubles cognitifs, ainsi que et les troubles d’apprentissage et neurologiques.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 
 	<!-- Write closure template -->

--- a/learning/esdc-self-paced-web-accessibility-course/module1/types-of-disabilities.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/types-of-disabilities.html
@@ -10,8 +10,8 @@
 		content="Defines the types of disability and their design considerations. Covers blind, low vision, colour blind, auditory disability, deaf-blind, motor disabilities, reading disabilities, and cognitive, learning and neurological disorders.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 
 

--- a/learning/esdc-self-paced-web-accessibility-course/module1/web-accessibility-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/web-accessibility-fr.html
@@ -10,8 +10,8 @@
 		content="Définit le but, la portée et les avantages de l’accessibilité du Web.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module1/web-accessibility.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module1/web-accessibility.html
@@ -10,8 +10,8 @@
 		content="Defines the purpose, scope and benefits of web accessibility.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/best-practice-mod-10-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/best-practice-mod-10-fr.html
@@ -10,8 +10,8 @@
 		content="Résumé des pratiques exemplaires du module 10 – Méthodes de saisie">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/best-practice-mod-10.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/best-practice-mod-10.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 10 – Input modalities">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/index-fr.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/index.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/introduction-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/introduction-fr.html
@@ -10,7 +10,7 @@
 		content="Décrit les avantages pour l’utilisateur et énumère les sujets abordés dans le module 10 – Méthodes de saisie">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/introduction.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/introduction.html
@@ -10,7 +10,7 @@
 		content="Describes the user benefits and lists the topics covered in Module 10 – Input modalities">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/keyboard-input-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/keyboard-input-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative à la saisie au moyen du clavier. Les sujets comprennent la cible du clavier, l’ordre de la cible, l’indicateur visuel de la cible, les fonctionnalités du clavier et les pièges.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/keyboard-input.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/keyboard-input.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to keyboard input. Topics include keyboard focus, focus order, visual focus indicator, keyboard functionality and traps">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/motion-actuation-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/motion-actuation-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative à la commande par le mouvement (p. ex. geste, secousse ou basculement)">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/motion-actuation.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/motion-actuation.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to motion actuation (e.g. gesturing, shaking or tilting).">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/mouse-input-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/mouse-input-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative à la saisie au moyen de la souris. Cette page aborde deux critères : le contenu accessible lorsqu’on le survole avec le pointeur ou qu’on le sélectionne et l’annulation du pointeur.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/mouse-input.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/mouse-input.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to mouse input. This page covers two criteria: Content on hover or focus, and pointer cancellation">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/touch-input-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/touch-input-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative à la saisie au moyen d’une touche ou du pointeur. Les sujets comprennent les gestes de commande du pointeur et la taille de la cible.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/touch-input.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/touch-input.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to touch/pointer input. Topics include pointer gestures and target size.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/voice-input-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/voice-input-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative à la saisie vocale">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module10/voice-input.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module10/voice-input.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to voice input">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module11/aria-live-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module11/aria-live-fr.html
@@ -14,8 +14,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../../css/a11y-dark.css" />

--- a/learning/esdc-self-paced-web-accessibility-course/module11/aria-live.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module11/aria-live.html
@@ -12,8 +12,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../../css/a11y-dark.css" />

--- a/learning/esdc-self-paced-web-accessibility-course/module11/best-practice-mod-11-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module11/best-practice-mod-11-fr.html
@@ -12,8 +12,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="../../../css/a11y-dark.css" />

--- a/learning/esdc-self-paced-web-accessibility-course/module11/best-practice-mod-11.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module11/best-practice-mod-11.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 11 – ARIA Live and time limits">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module11/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module11/index-fr.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module11/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module11/index.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module11/time-limits-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module11/time-limits-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux limites temporelles">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module11/time-limits.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module11/time-limits.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to time limits">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module12/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module12/index-fr.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/esdc-self-paced-web-accessibility-course/module12/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module12/index.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/esdc-self-paced-web-accessibility-course/module12/introduction-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module12/introduction-fr.html
@@ -10,8 +10,8 @@
 		content="Ce module présente les pratiques exemplaires en matière d’accessibilité relative aux widgets ARIA.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module12/introduction.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module12/introduction.html
@@ -10,8 +10,8 @@
 		content="This module provides accessibility best practices related to ARIA widgets.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/best-practice-mod-2-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/best-practice-mod-2-fr.html
@@ -10,8 +10,8 @@
 		content="Résumé des pratiques exemplaires du module 2 – Structure de page et contenu sémantique">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/best-practice-mod-2.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/best-practice-mod-2.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 2 - Page structure and semantics">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/content-structure-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/content-structure-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative à une structure de page efficace. Décrit les balises, les en têtes, les menus, les bannières, les paragraphes, les listes, les tableaux appropriés et les autres fonctionnalités.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/content-structure.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/content-structure.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to proper page structure. Describes appropriate markup, headings, menus, banners, paragraphs, lists, tables and other features.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/headings-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/headings-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux en têtes. Les en têtes de pages Web aident les utilisateurs à reconnaître différentes sections du contenu.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/headings.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/headings.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to headings. This helps users identify different sections within the content.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/iframes-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/iframes-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux balises iframe. Les balises iframes permettent aux concepteurs d’intégrer tout type de contenu provenant d’une autre page Web.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/iframes.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/iframes.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to iFrames. This enables designers to embed any type of content from another web page.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/index-fr.html
@@ -10,8 +10,8 @@
 		content="Ce module présente les pratiques exemplaires en matière d’accessibilité relative aux repères, aux rubriques, à la structure du contenu, à la langue, aux listes, aux balises iframes, à l’analyse syntaxique et à la validité.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/index.html
@@ -10,8 +10,8 @@
 		content="This module provides accessibility best practices related to landmarks, headings, content structure, language, lists, iframes, parsing and validity.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/landmarks-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/landmarks-fr.html
@@ -11,8 +11,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux zones de page. Les points de repère permettent aux utilisateurs du lecteur d’écran de repérer les sections importantes d’une page Web et de naviguer directement vers celles-ci.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/landmarks.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/landmarks.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to page regions. This enables screen reader users to identify and navigate directly to important sections of a web page.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/language-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/language-fr.html
@@ -11,8 +11,8 @@
 		<!-- Meta data-->
 
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/language.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/language.html
@@ -11,8 +11,8 @@
 		<!-- Meta data-->
 
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/lists-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/lists-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l'accessibilit&eacute; relative aux listes. D&eacute;cris comment les listes peuvent &ecirc;tre reconnaissables et navigables pour les utilisateurs du lecteur d'&eacute;cran.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/lists.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/lists.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to lists. Describes how lists can be recognizable and navigable to screen reader users.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/parsing-and-validity-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/parsing-and-validity-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative à l’analyse syntaxique et à la validité. Les défauts de balisage peuvent faire en sorte que les agents utilisateurs ne parviennent pas à analyser le contenu ou à le présenter différemment.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module2/parsing-and-validity.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module2/parsing-and-validity.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to parsing and validity. Defects in the markup can cause user agents to fail to parse it or to present the content differently.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module3/best-practice-mod-3-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/best-practice-mod-3-fr.html
@@ -10,8 +10,8 @@
 		content="Résumé des pratiques exemplaires du module 3 – Liens et navigation">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module3/best-practice-mod-3.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/best-practice-mod-3.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 3 - Links and navigation">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module3/consistency-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/consistency-fr.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module3/consistency.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/consistency.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module3/context-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/context-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur changement de contexte.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module3/context.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/context.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to changing context. Topics include on input and on focus.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module3/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/index-fr.html
@@ -10,8 +10,8 @@
 		content="Ce module présente les pratiques exemplaires en matière d’accessibilité relative aux liens et à la navigation. Les sujets comprennent l’objet du lien, l’activation du lien, l’indicateur visuel de la cible, la distinction entre les liens et le texte et l’ouverture des liens dans une nouvelle fenêtre. Les sujets suivants sont aussi abordés : les blocs de navigation, l’uniformité, les liens de saut de navigation, la table des matières, les cibles et l’ordre des cibles.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module3/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/index.html
@@ -10,8 +10,8 @@
 		content="This module provides accessibility best practices related to links and navigation. Topics include link purpose, link activation, visual focus indicator, distinguishing links from text and opening links in new window. Topics also include blocks of navigation, consistency, skip navigation links, table of contents, and focus and focus order.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">
 </head>

--- a/learning/esdc-self-paced-web-accessibility-course/module3/links-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/links-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux liens. Il est important que les liens soient descriptifs et logiques en soi, c’est-à-dire  , sans les phrases ou le contenu environnant.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module3/links.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/links.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to links. It is important for links to be descriptive and to make sense without the surrounding sentences or content.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module3/navigation-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/navigation-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative à la navigation. Les sujets comprennent les blocs de navigation, la cohérence, le saut de navigation, les liens, la table des matières et l’ordre des cibles.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module3/navigation.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module3/navigation.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to navigation. Topics include blocks of navigation, consistency, skip navigation, links, table of contents and focus order.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/additional-tips-and-tricks-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/additional-tips-and-tricks-fr.html
@@ -10,8 +10,8 @@
 		content="Conseils, astuces et directives supplémentaires concernant les tableaux">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/additional-tips-and-tricks.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/additional-tips-and-tricks.html
@@ -10,8 +10,8 @@
 		content="Additional tips, tricks and guidance for tables">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/best-practice-mod-4-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/best-practice-mod-4-fr.html
@@ -10,8 +10,8 @@
 		content="Résumé des pratiques exemplaires du module 4 – Tableaux">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/best-practice-mod-4.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/best-practice-mod-4.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 4 - Tables">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/caption-summary-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/caption-summary-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux sous-titres et au résumé des tableaux">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/caption-summary.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/caption-summary.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to table caption and summary.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/index-fr.html
@@ -10,8 +10,8 @@
 		content="Ce module présente les pratiques exemplaires en matière d’accessibilité relative aux tableaux. Les sujets abordés comprennent les concepts des tableaux, un en tête, deux en têtes, les en têtes irrégulières, les tableaux à en têtes multiples ainsi que les sous- titres et les résumés.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/index.html
@@ -10,8 +10,8 @@
 		content="This module provides accessibility best practices related to tables. Topics include table concepts, one header, two headers, irregular headers, multi-headers tables, as well as captions and summary.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">
 </head>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/irregular-headers-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/irregular-headers-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux tableaux dont les en têtes sont irréguliers et qui comportent plusieurs colonnes ou rangées">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/irregular-headers.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/irregular-headers.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to tables with irregular headers that span multiple columns or rows.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/multi-level-headers-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/multi-level-headers-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux tableaux comportant des en têtes à niveaux multiples. Cela comprend les en têtes à trois niveaux ou les en têtes de colonne qui se répètent ou changent au milieu d’un tableau.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/multi-level-headers.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/multi-level-headers.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to tables with multi-level headers. This includes headers stacked three deep, or column headers that repeat or change partway down a table.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/one-header-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/one-header-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux tableaux comptant un seul en tête. Décrit l’accessibilité des tableaux simples avec des en têtes de ligne ou de colonne.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/one-header.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/one-header.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to tables with one header. Describes accessibility of simple tables with either row headers or column headers.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	

--- a/learning/esdc-self-paced-web-accessibility-course/module4/tables-concepts-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/tables-concepts-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux concepts de base des tableaux.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/tables-concepts.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/tables-concepts.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to basic table concepts.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/tables-resources-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/tables-resources-fr.html
@@ -10,8 +10,8 @@
 		content="Liens vers les ressources de la BOEW liées aux tableaux, y compris le guide de style de la BOEW, le module d’extension DataTables et le validateur de tableaux de la BOEW.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/tables-resources.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/tables-resources.html
@@ -10,8 +10,8 @@
 		content="Links to resources in WET related to tables including WET style guide, DataTables plugin and WET table validator.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module4/two-headers-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/two-headers-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux tableaux comptant deux en têtes. Décrit l’utilisation de l’attribut de portée.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module4/two-headers.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module4/two-headers.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to tables with two headers. Describes the use of scope attribute.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">
 	<script src="../../../scripts/highlight.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/module5/alt-decision-tree-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/alt-decision-tree-fr.html
@@ -10,8 +10,8 @@
 		content="Décrit comment utiliser l’attribut optionnel de l’élément img dans différentes situations.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/alt-decision-tree.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/alt-decision-tree.html
@@ -10,8 +10,8 @@
 		content="Describes how to use the alt attribute of the img element in different situations.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/animated-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/animated-images-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux images animées. Ces images peuvent distraire les utilisateurs ou même causer des crises épileptiques.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/animated-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/animated-images.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to animated images. These images can distract users and cause seizures.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/best-practice-mod-5-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/best-practice-mod-5-fr.html
@@ -10,8 +10,8 @@
 		content="Résumé des pratiques exemplaires du module 5 – Images">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/best-practice-mod-5.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/best-practice-mod-5.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 5 - Images">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/captcha-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/captcha-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux SVG. Les SVG sont des images en deux dimensions définies dans des fichiers texte XML.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/captcha.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/captcha.html
@@ -14,8 +14,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/complex-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/complex-images-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux images complexes. Décrit la façon de rédiger de longues descriptions et les approches pour les fournir.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/complex-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/complex-images.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to complex images. Describes how to write long descriptions and approaches to provide them.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/decorative-redundant-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/decorative-redundant-images-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux Images décoratives ou redondantes. Ces images n’ajoutent pas d’information utile à une page ou ont déjà du contenu compris dans le texte adjacent.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/decorative-redundant-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/decorative-redundant-images.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to decorative and redundant images. These images do not add useful information to a page, or have content already conveyed in adjacent text.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/figcaption-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/figcaption-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux figures et à l’élément figcaption. Cette page traite de ce que devrait contenir un élément figcaption et de la façon de l’utiliser dans un texte optionnel.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/figcaption.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/figcaption.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to Figure and figcaption. This page covers what figcaption should include and how to use it with alt text.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/functional-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/functional-images-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux images fonctionnelles. Les images fonctionnelles servent de boutons, de liens et de commandes personnalisées.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/functional-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/functional-images.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to functional images. Functional images are used as buttons, links, and custom controls.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/groups-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/groups-images-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux groupes d’images. Un groupe d’images représente un élément d’information unique ou une collection d’images.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/groups-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/groups-images.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to groups of images. Groups of images represent a single piece of information or a collection of images.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/image-maps-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/image-maps-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux iconocartes. Une iconocarte relie les zones géométriques d’une image. Elle comprend un élément img et un élément map.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/image-maps.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/image-maps.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to image maps. An image map links geometric areas of an image. It consists of an img element and a map element.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/images-text-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/images-text-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux images de texte. Il faut éviter ces images.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/images-text.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/images-text.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to images of text. These images should be avoided.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/index-fr.html
@@ -10,8 +10,8 @@
 		content="Ce module présente les pratiques exemplaires en matière d’accessibilité relative aux images. Les sujets abordés comprennent les équivalents textuels et les images informatives, décoratives, redondantes et fonctionnelles.  les images animées, les images complexes, les groupes d’images, les iconocartes et les graphiques vectoriels adaptables (SVG) sont aussi abordés dans ce module.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/index.html
@@ -13,8 +13,8 @@
 		content="This module provides accessibility best practices related to images. Topics include text alternatives, informative, decorative, redundant, and functional images. Topics also include animated images, complex images, groups of images, image maps and SVG.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/informative-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/informative-images-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux images informatives. Les images informatives communiquent des renseignements simples qui peuvent être exprimés dans une courte phrase.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/informative-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/informative-images.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to informative images. These images convey simple information that can be expressed in a short phrase.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/svg-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/svg-images-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux SVG. Les SVG sont des images en deux dimensions définies dans des fichiers texte XML.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/svg-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/svg-images.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to SVG. SVG are 2D images defined in XML text files.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/text-alternatives-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/text-alternatives-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux équivalents textuels. Les images doivent avoir un équivalent textuel qui répond à un but équivalent.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/text-alternatives.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/text-alternatives.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to text alternatives. Images must have text alternatives that serve the equivalent purpose.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/tips-and-tricks-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/tips-and-tricks-fr.html
@@ -10,8 +10,8 @@
 		content="Conseils, astuces et directives supplémentaires concernant les images.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module5/tips-and-tricks.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module5/tips-and-tricks.html
@@ -10,8 +10,8 @@
 		content="Additional tips, tricks and guidance for images.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/best-practice-mod-6-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/best-practice-mod-6-fr.html
@@ -10,8 +10,8 @@
 		content="Résumé des pratiques exemplaires du module 6 – Formulaires">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/best-practice-mod-6.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/best-practice-mod-6.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 6 - forms">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/custom-controls-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/custom-controls-fr.html
@@ -12,8 +12,8 @@
             />
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css" />

--- a/learning/esdc-self-paced-web-accessibility-course/module6/custom-controls.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/custom-controls.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to custom controls. This page provides a high-level overview of what to consider when developing custom form controls.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/form-instructions-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/form-instructions-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative aux instructions sur les formulaires. Aide les utilisateurs à comprendre la façon de remplir un formulaire et d’en utiliser les commandes individuelles.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/form-instructions.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/form-instructions.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to form instructions. Help users understand how to complete the form and use individual form controls.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/forms-concepts-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/forms-concepts-fr.html
@@ -10,7 +10,7 @@
 		content="Présente les concepts de base des formulaires et fournit une liste des sujets abordés dans le module.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/forms-concepts.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/forms-concepts.html
@@ -10,7 +10,7 @@
 		content="Introduces basic concepts of forms and provides a list of topics covered this module.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/grouping-controls-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/grouping-controls-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative aux regroupements des commandes. Les regroupements des commandes de regroupement de formulaires en facilitent la compréhension.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/grouping-controls.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/grouping-controls.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to grouping controls. Grouping related form controls makes forms more understandable.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/identifying-input-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/identifying-input-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative à la détermination du but de la saisie. Décrit comment définir la sémantique des champs de saisie à l’aide de la fonction de remplissage automatique.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/identifying-input.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/identifying-input.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to identifying input purpose. Describes how to define semantics of input fields with the autocomplete attribute.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/index-fr.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/index.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/labelling-controls-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/labelling-controls-fr.html
@@ -10,7 +10,7 @@
 			content="Lignes directrices sur l’accessibilité relative aux commandes d’étiquetage. Présente les étiquettes pour décrire le but d’une commande de formulaire.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/labelling-controls.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/labelling-controls.html
@@ -10,7 +10,7 @@
 			content="Accessibility guidelines related to labeling controls. Provide labels to describe the purpose of the form control.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/multi-step-forms-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/multi-step-forms-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative aux formulaires à étapes multiples. Divise un long formulaire en une série de formulaires plus petits.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/multi-step-forms.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/multi-step-forms.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to multi-step forms. Divide a long form into a stepped series of smaller forms.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/user-notifications-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/user-notifications-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative aux avis aux utilisateurs. Lorsqu’un utilisateur soumet un formulaire, cette fonction l’avise de la réussite ou de toute erreur.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/user-notifications.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/user-notifications.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to user notifications. Upon form submission, notify the user of success or of any errors.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/validating-input-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/validating-input-fr.html
@@ -10,7 +10,7 @@
 		content="Lignes directrices sur l’accessibilité relative à la validation de la saisie. Cette étape aide les utilisateurs à éviter des erreurs.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module6/validating-input.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module6/validating-input.html
@@ -10,7 +10,7 @@
 		content="Accessibility guidelines related to validating input. This will help users avoid mistakes.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/best-practice-mod-7-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/best-practice-mod-7-fr.html
@@ -10,8 +10,8 @@
             content="Résumé des pratiques exemplaires du module 7 – Conception visuelle et couleurs">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/best-practice-mod-7.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/best-practice-mod-7.html
@@ -10,8 +10,8 @@
             content="Summary of best practices in Module 7 – Visual design and colours">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/colour-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/colour-fr.html
@@ -10,8 +10,8 @@
             content="Lignes directrices sur l’accessibilité relative aux couleurs. Assurez- vous que la couleur n’est pas la seule façon de communiquer l’information">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/colour.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/colour.html
@@ -10,8 +10,8 @@
             content="Accessibility guidelines related to colours. Ensure colour is not the only way information is conveyed">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/contrast-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/contrast-fr.html
@@ -10,8 +10,8 @@
             content="Lignes directrices sur l’accessibilité relative au contraste. Décrit le rapport de contraste minimal entre les couleurs de fond et de premier plan">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/contrast.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/contrast.html
@@ -10,8 +10,8 @@
             content="Accessibility guidelines related to contrast. Describes the minimum contrast ratio between background and foreground colour">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/css-generated-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/css-generated-fr.html
@@ -10,8 +10,8 @@
             content="Lignes directrices sur l’accessibilité relative au contenu généré par les feuilles de style en cascade CSS. Éviter le contenu généré par feuilles de style en cascade CSS">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/css-generated.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/css-generated.html
@@ -10,8 +10,8 @@
             content="Accessibility guidelines related to CSS generated content. Avoid CSS-generated content">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/hiding-content-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/hiding-content-fr.html
@@ -10,8 +10,8 @@
             content="Lignes directrices sur l’accessibilité relative au masquage et à l’affichage du contenu. Décrit la façon de masquer le contenu et les exigences pour afficher le contenu masqué lorsqu’on le survole avec le pointeur ou qu’on le sélectionne">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/hiding-content.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/hiding-content.html
@@ -10,8 +10,8 @@
             content="Accessibility guidelines related to hiding and exposing content. Describes how to hide content and requirements for exposing hidden content on hover or focus">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/index-fr.html
@@ -11,8 +11,8 @@
          <meta name="robots" content="noindex">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
       	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/index.html
@@ -11,8 +11,8 @@
          <meta name="robots" content="noindex">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
       	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/introduction-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/introduction-fr.html
@@ -10,8 +10,8 @@
             content="Décrit les avantages pour l’utilisateur et énumère les sujets abordés dans le module 7 – Conception visuelle et couleurs.">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/introduction.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/introduction.html
@@ -10,8 +10,8 @@
             content="Describes the user benefits and lists the topics covered in Module 7 – Visual design and colours">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/textspacing-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/textspacing-fr.html
@@ -10,8 +10,8 @@
             content="Lignes directrices sur l’accessibilité relative à l’espacement du texte. L’espace accru entre les paragraphes, les lignes, les mots et les lettres facilite la lecture pour certains utilisateurs malvoyants ou atteints de dyslexie">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/textspacing.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/textspacing.html
@@ -10,8 +10,8 @@
             content="Accessibility guidelines related to text spacing. Increased space between paragraphs, lines, words, and letters helps some users with low vision and users with dyslexia">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/visual-proximity-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/visual-proximity-fr.html
@@ -10,8 +10,8 @@
             content="Lignes directrices sur l’accessibilité relative à la proximité visuelle des étiquettes. Décrit le positionnement des étiquettes dans les champs du formulaire">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module7/visual-proximity.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module7/visual-proximity.html
@@ -10,8 +10,8 @@
             content="Accessibility guidelines related to visual proximity of labels. Describes positioning labels for form fields">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="../../../scripts/refTop.min.js"></script>
          <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/best-practice-mod-8-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/best-practice-mod-8-fr.html
@@ -10,8 +10,8 @@
 		content="Résumé des pratiques exemplaires du module 8 – Conception adaptée et zoom">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/best-practice-mod-8.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/best-practice-mod-8.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 8 – Responsive design and zoom">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/index-fr.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/index.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/introduction-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/introduction-fr.html
@@ -10,8 +10,8 @@
 		content="Décrit les avantages pour l’utilisateur et énumère les sujets abordés dans le module 8 – Conception adaptée et zoom">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/introduction.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/introduction.html
@@ -10,8 +10,8 @@
 		content="Describes the user benefits and lists the topics covered in Module 8 – Zoom and responsive design">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/orientation-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/orientation-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative à l’orientation. Décrit l’exigence de permettre aux utilisateurs d’afficher le contenu en orientation portrait ou paysage">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/orientation.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/orientation.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to orientation. Describes the requirement for enabling users to view content in portrait or landscape orientation">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-design-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-design-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative à la conception adaptée. La conception adaptée utilise le langage HTML et les feuilles de style en cascade CSS pour redimensionner, masquer, réduire ou agrandir automatiquement un site Web.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-design.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-design.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to responsive design. Responsive design use HTML and CSS to automatically resize, hide, shrink, or enlarge a website">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-forms-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-forms-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux formulaires adaptés. Décrit la façon de concevoir des formulaires qui sont compatibles avec des fenêtres d’affichage de différentes tailles.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-forms.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-forms.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to responsive forms. Describes how to design forms to work with different viewport sizes">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-images-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-images-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux images adaptées. Décrit la façon de concevoir des images qui sont compatibles avec des fenêtres d’affichage de différentes tailles.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-images.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-images.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to responsive images. Describes how to design images to work with different viewport sizes">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-objects-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-objects-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux objets et aux modules d’extension adaptées. Décrit la façon de concevoir des objets et des modules d’extension qui sont compatibles avec des fenêtres d’affichage de différentes tailles">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-objects.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-objects.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to responsive objects and plugins. Describes how to design objects and plugins to work with different viewport sizes">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-tables-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-tables-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux tableaux adaptées. Décrit la façon de concevoir des tableaux qui sont compatibles avec des fenêtres d’affichage de différentes tailles">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-tables.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-tables.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to responsive tables. Describes how to design tables to work with different viewport sizes">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-text-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-text-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative au texte adapté. Décrit la façon de concevoir des conteneurs de texte qui sont compatibles avec des fenêtres d’affichage de différentes tailles">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-text.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-text.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to responsive text. Describes how to design text containers to work with different viewport sizes">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-ui-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-ui-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux composants d’interface utilisateur adaptée. Décrit la façon de concevoir des composants d’interface utilisateur qui sont compatibles avec différentes fenêtres d’affichage.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-ui.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-ui.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to responsive UI components. Describes how to design UI components to work with different viewport sizes">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-video-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-video-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux vidéos adaptées. Décrit la façon de concevoir des vidéos qui sont compatibles avec des fenêtres d’affichage de différentes tailles">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/responsive-video.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/responsive-video.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to responsive videos. Describes how to design videos to work with different viewport sizes">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/zoom-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/zoom-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative au zoom. Décrit les exigences relatives au reformage du contenu et au redimensionnement du texte.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module8/zoom.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module8/zoom.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to Zoom. Describes requirements for content reflow and text resize">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/animation-motion-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/animation-motion-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative à l’animation et au mouvement. Permet aux utilisateurs de désactiver l’animation de mouvement déclenché par une interaction.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/animation-motion.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/animation-motion.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to animations and motion. Allow users to disable motion animation triggered by interaction">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/audio-control-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/audio-control-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relatives à l'audio automatique. Permettent à l'utilisateur de mettre l'audio en pause ou en haut, ou de contrôler le volume indépendamment du volume du système.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/audio-control.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/audio-control.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to audio that automatically. Enable the user to pause or top the audio, or control the volume independ of the system volume.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/best-practice-mod-9-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/best-practice-mod-9-fr.html
@@ -10,8 +10,8 @@
 		content="Résumé des pratiques exemplaires du module 9 – Animation audio, vidéo et de mouvement">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/best-practice-mod-9.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/best-practice-mod-9.html
@@ -10,8 +10,8 @@
 		content="Summary of best practices in Module 9 – Audio, Video and Motion animation">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/captions-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/captions-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux sous- titres. Les sous- titres sont une version texte de la parole et d’autres éléments d’information audio nécessaires pour comprendre le contenu">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/captions.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/captions.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to captions. Captions are a text version of the speech and other audio information needed to understand the content">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/description-visual-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/description-visual-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative à l’audiodescription et à la transcription descriptive. Cette page décrit les méthodes pour fournir une audiodescription et rédiger des descriptions">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/description-visual.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/description-visual.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to audio description and descriptive transcript. This page describes methods for providing audio description and writing descriptions">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/flashing-content-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/flashing-content-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative au contenu clignotant. Le contenu clignotant peut causer des crises épileptiques. Éviter le contenu qui clignote plus de trois fois par seconde">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/flashing-content.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/flashing-content.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to flashing content. Flashing content can cause seizures. Avoid content that flashes more than 3 times per second">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/index-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/index-fr.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/index.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/index.html
@@ -11,8 +11,8 @@
 	<meta name="robots" content="noindex">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/esdc-course.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/introduction-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/introduction-fr.html
@@ -10,8 +10,8 @@
 		content="Décrit les quatre méthodes relatives à l’accessibilité audio et vidéo : sous- titres, transcriptions, audiodescription ou texte descriptif et langage gestuel">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/introduction.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/introduction.html
@@ -10,8 +10,8 @@
 		content="Describes the four methods that audio and video accessibility draws on: Captions, transcripts, audio description or descriptive text, and sign language">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/media-player-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/media-player-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative au lecteur multimédia. Le lecteur multimédia doit être accessible par le clavier et être compatible avec les lecteurs d’écran">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/media-player.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/media-player.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to media player. The media player itself should be keyboard accessible and screen reader compatible.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/pause-stop-hide-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/pause-stop-hide-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative au contenu qui bouge, clignote, défile ou se met à jour automatiquement fournit aux utilisateurs un moyen de mettre en pause, d’arrêter ou de masquer du contenu en mouvement">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/pause-stop-hide.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/pause-stop-hide.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to content that moves, blinks, scrolls or auto-updates. Provide a way for users to pause, stop or hide moving content">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/policy-matrix-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/policy-matrix-fr.html
@@ -10,8 +10,8 @@
 		content="Les tableaux matriciels des politiques ci- dessous présentent la liste des exigences du gouvernement du Canada relatives aux sous- titres, aux transcriptions, à l’audiodescription et au langage gestuel.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/policy-matrix.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/policy-matrix.html
@@ -10,8 +10,8 @@
 		content="The policy matrix tables below list Government of Canada requirements for captions, transcripts, audio description and sign language">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/sign-language-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/sign-language-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative au langage des signes. Le langage des signes utilise les mouvements des mains et des bras, les expressions faciales et les positions du corps pour transmettre le sens.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/sign-language.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/sign-language.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to sign language. Sign languages use hand and arm movements, facial expressions, and body positions to convey meaning.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/transcribing-audio-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/transcribing-audio-fr.html
@@ -10,8 +10,8 @@
 		content="Cette page décrit la façon de transcrire et les éléments à transcrire.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/transcribing-audio.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/transcribing-audio.html
@@ -10,8 +10,8 @@
 		content="This page describes how to transcribe and what to transcribe">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/transcripts-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/transcripts-fr.html
@@ -10,8 +10,8 @@
 		content="Lignes directrices sur l’accessibilité relative aux transcriptions. Les transcriptions sont une version texte de la parole et de l’information audio non vocale qui est nécessaire pour comprendre le contenu.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/module9/transcripts.html
+++ b/learning/esdc-self-paced-web-accessibility-course/module9/transcripts.html
@@ -10,8 +10,8 @@
 		content="Accessibility guidelines related to transcripts. Transcripts are text version of the speech and non-speech audio information needed to understand the content.">
 		<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../../../scripts/refTop.min.js"></script>
 	<link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/search/search_form-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/search/search_form-fr.html
@@ -6,7 +6,7 @@
 		<title>Search</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">
 		<meta name="description" content="Site map">
-		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
+		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
 				  hljs.highlightAll();
 				</script><link rel="stylesheet" href="../../../css/esdc-course.css"><script src="../../../scripts/expandcollapseall.js"></script><link rel="stylesheet" href="../../../css/expandcollapseall.css"><script src="../../../scripts/esdc-course-wcag-view.js"></script></head>
 	<body vocab="https://schema.org/" typeof="WebPage" id="wcag-view">

--- a/learning/esdc-self-paced-web-accessibility-course/search/search_form.html
+++ b/learning/esdc-self-paced-web-accessibility-course/search/search_form.html
@@ -6,7 +6,7 @@
 		<title>Search</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">
 		<meta name="description" content="Site map">
-		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
+		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
 				  hljs.highlightAll();
 				</script><link rel="stylesheet" href="../../../css/esdc-course.css"><script src="../../../scripts/expandcollapseall.js"></script><link rel="stylesheet" href="../../../css/expandcollapseall.css"><script src="../../../scripts/esdc-course-wcag-view.js"></script></head>
 	<body vocab="https://schema.org/" typeof="WebPage" id="wcag-view">

--- a/learning/esdc-self-paced-web-accessibility-course/sitemap/sitemap-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/sitemap/sitemap-fr.html
@@ -11,8 +11,8 @@
       <!-- Meta data-->
       <!-- Load closure template scripts -->
 	  	<script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-      <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+      <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
       <!-- Write closure template -->
       <script src="../../../scripts/refTop.min.js"></script>
       <link rel="stylesheet" href="../../../css/a11y-dark.css">

--- a/learning/esdc-self-paced-web-accessibility-course/sitemap/sitemap.html
+++ b/learning/esdc-self-paced-web-accessibility-course/sitemap/sitemap.html
@@ -10,8 +10,8 @@
     <!-- Meta data-->
     <!-- Load closure template scripts -->
 	<script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>

--- a/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view - Copy.html
+++ b/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view - Copy.html
@@ -5,7 +5,7 @@
 		<title>WCAG view</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">
 		<meta name="description" content="Site map">
-		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
+		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
 				  hljs.highlightAll();
 				</script><link rel="stylesheet" href="../../../css/esdc-course.css"><script src="../../../scripts/expandcollapseall.js"></script><link rel="stylesheet" href="../../../css/expandcollapseall.css"><script src="../../../scripts/esdc-course-wcag-view.js"></script></head>
 	<body vocab="https://schema.org/" typeof="WebPage" id="wcag-view">

--- a/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view-fr - Copy.html
+++ b/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view-fr - Copy.html
@@ -5,7 +5,7 @@
 		<title>Vue WCAG</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">
 		<meta name="description" content="Index WCAG du cours">
-		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
+		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
 				  hljs.highlightAll();
 				</script><link rel="stylesheet" href="../../../css/esdc-course.css"><script src="../../../scripts/expandcollapseall.js"></script><link rel="stylesheet" href="../../../css/expandcollapseall.css"><script src="../../../scripts/esdc-course-wcag-view.js"></script></head>
 	<body vocab="https://schema.org/" typeof="WebPage" id="wcag-view">

--- a/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view-fr.html
+++ b/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view-fr.html
@@ -5,7 +5,7 @@
 		<title>Vue WCAG</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">
 		<meta name="description" content="Index WCAG du cours">
-		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
+		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
 				  hljs.highlightAll();
 				</script><link rel="stylesheet" href="../../../css/esdc-course.css"><script src="../../../scripts/expandcollapseall.js"></script><link rel="stylesheet" href="../../../css/expandcollapseall.css"><script src="../../../scripts/esdc-course-wcag-view.js"></script></head>
 	<body vocab="https://schema.org/" typeof="WebPage" id="wcag-view">

--- a/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view.html
+++ b/learning/esdc-self-paced-web-accessibility-course/wcag/wcag-view.html
@@ -5,7 +5,7 @@
 		<title>WCAG view</title>
 		<meta content="width=device-width,initial-scale=1" name="viewport">
 		<meta name="description" content="Site map">
-		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script><script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
+		<meta name="robots" content="noindex"><script src="https://canada.ca/etc/designs/canada/cdts/gcweb/v4_0_44/wet-boew/js/jquery/2.2.4/jquery.min.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script><script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script><script src="../../../scripts/refTop.min.js"></script><link rel="stylesheet" href="../../../css/a11y-dark.css"><script src="../../../scripts/highlight.min.js"></script><script>
 				  hljs.highlightAll();
 				</script><link rel="stylesheet" href="../../../css/esdc-course.css"><script src="../../../scripts/expandcollapseall.js"></script><link rel="stylesheet" href="../../../css/expandcollapseall.css"><script src="../../../scripts/esdc-course-wcag-view.js"></script></head>
 	<body vocab="https://schema.org/" typeof="WebPage" id="wcag-view">

--- a/learning/index-fr.html
+++ b/learning/index-fr.html
@@ -15,8 +15,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
   </head>

--- a/learning/index.html
+++ b/learning/index.html
@@ -15,8 +15,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
   </head>

--- a/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path-en.html
+++ b/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path-en.html
@@ -18,8 +18,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
   </head>

--- a/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path-fr.html
+++ b/learning/learning-path-for-auditors/document-auditor-learning-path/document-auditor-learning-path-fr.html
@@ -17,8 +17,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
   </head>

--- a/learning/learning-path-for-auditors/document-auditor-learning-path/index-fr.html
+++ b/learning/learning-path-for-auditors/document-auditor-learning-path/index-fr.html
@@ -18,8 +18,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
   </head>

--- a/learning/learning-path-for-auditors/document-auditor-learning-path/index.html
+++ b/learning/learning-path-for-auditors/document-auditor-learning-path/index.html
@@ -18,8 +18,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
   </head>

--- a/learning/learning-path-for-auditors/index-fr.html
+++ b/learning/learning-path-for-auditors/index-fr.html
@@ -13,8 +13,8 @@
         content="EDSC s'engage à assurer l'accessibilité de son site web et de ses ressources bureautiques. Ces sessions d'entraînement présentent les normes et les directives fédérales en matière d'accessibilité et mettent l'accent sur les exigences, les rôles et les responsabilités liés au respect de ces normes.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/learning-path-for-auditors/index.html
+++ b/learning/learning-path-for-auditors/index.html
@@ -13,8 +13,8 @@
         content="ESDC is committed to ensuring the accessibility of its websites and desktop assets are meeting Canadian standards. These coaching sessions outline federal standards and guidelines on accessibility and emphasizes the requirements, roles and responsibilities involved in compliance with these standards.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/learning/learning-path-for-auditors/web-auditor-learning-path/web-auditor-learning-path-en.html
+++ b/learning/learning-path-for-auditors/web-auditor-learning-path/web-auditor-learning-path-en.html
@@ -18,8 +18,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
   </head>

--- a/learning/learning-path-for-auditors/web-auditor-learning-path/web-auditor-learning-path-fr.html
+++ b/learning/learning-path-for-auditors/web-auditor-learning-path/web-auditor-learning-path-fr.html
@@ -17,8 +17,8 @@
     />
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../../scripts/refTop.min.js"></script>
   </head>

--- a/learning/offline/index-fr.html
+++ b/learning/offline/index-fr.html
@@ -13,8 +13,8 @@
         content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/learning/offline/index.html
+++ b/learning/offline/index.html
@@ -13,8 +13,8 @@
         content="During a time of crisis (e.g., the COVID-19 pandemic), the Government of Canada (GOC ) network is limited to essential employees, with few exceptions. This page contains information pertaining to working offline from the GOC network that includes: tools and applications for continuation of work, team communication software and a listing of tasks that can/should be completed.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	
 
     <!-- Write closure template -->

--- a/learning/teleworking-essentials.html
+++ b/learning/teleworking-essentials.html
@@ -13,8 +13,8 @@
         content="During a time of crisis (e.g., the COVID-19 pandemic), the Government of Canada (GOC ) network is limited to essential employees, with few exceptions. This page contains information pertaining to working offline from the GOC network that includes: tools and applications for continuation of work, team communication software and a listing of tasks that can/should be completed.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/projects/_template-en.html
+++ b/projects/_template-en.html
@@ -13,8 +13,8 @@
         content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/projects/_template-fr.html
+++ b/projects/_template-fr.html
@@ -13,8 +13,8 @@
         content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieu du travail.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/projects/index-fr.html
+++ b/projects/index-fr.html
@@ -13,8 +13,8 @@
         content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieu du travail.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <link rel="stylesheet" href="./styles/custom.css">
     <script src="../scripts/refTop.min.js"></script>

--- a/projects/index.html
+++ b/projects/index.html
@@ -13,8 +13,8 @@
         content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
     <link rel="stylesheet" href="./styles/custom.css">

--- a/resources/CART-services-Sign-Language-Interpreters-en.html
+++ b/resources/CART-services-Sign-Language-Interpreters-en.html
@@ -14,8 +14,8 @@
 		content="The most common accommodations for meetings or events are computer-assisted real-time transcription (CART) and interpretation services.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/CART-services-Sign-Language-Interpreters-fr.html
+++ b/resources/CART-services-Sign-Language-Interpreters-fr.html
@@ -13,8 +13,8 @@
         content="Les mesures d’adapatation les plus courantes pour les réunions ou les événements sont les services de traduction en temps réel des communications (CART en anglais) ainsi que les services d’interprétation.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/Official-languages-recommendations-en.html
+++ b/resources/Official-languages-recommendations-en.html
@@ -14,8 +14,8 @@
 		content="Unilingual meetings or events offered in both official languages (English and French) are preferred. There are, however, best practices to follow when it comes to bilingualism.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/Official-languages-recommendations-fr.html
+++ b/resources/Official-languages-recommendations-fr.html
@@ -13,8 +13,8 @@
         content="Les réunions ou les événements unilingues offerts dans les deux langues officielles (anglais et fran&ccedil;ais) sont à privilégier. Il y a cependant des meilleures pratiques à suivre lorsqu’il s’agit de bilinguisme. ">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/a11ycheck-en.html
+++ b/resources/a11ycheck-en.html
@@ -14,8 +14,8 @@
         content="">  
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/a11ycheck-fr.html
+++ b/resources/a11ycheck-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/a11ycheck-nonweb-en.html
+++ b/resources/a11ycheck-nonweb-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/a11ycheck-nonweb-fr.html
+++ b/resources/a11ycheck-nonweb-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-documents-en.html
+++ b/resources/accessible-documents-en.html
@@ -13,8 +13,8 @@
         content="The core steps needed for accessibility are the same regardless of whether your document is in HTML, Microsoft Word, Adobe PDF, or another document format. To assist you in making all your documents accessible, we have gathered various resources. ">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-documents-fr.html
+++ b/resources/accessible-documents-fr.html
@@ -16,8 +16,8 @@
         incluant les personnes avec un handicapes, puisse lire et comprendre vos documents.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-documents-questions-answers-fr.html
+++ b/resources/accessible-documents-questions-answers-fr.html
@@ -14,8 +14,8 @@
         content="liste de questions et réponses provenant de participants au cours 'Accessibilité - Création de contenu accessible à l'aide de Microsoft Office 365'">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-documents-questions-answers.html
+++ b/resources/accessible-documents-questions-answers.html
@@ -13,8 +13,8 @@
         content="List of questions and answers from participants of the 'Accessibility - creating accessible content using Microsoft Office 365' course ">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-image-fr.html
+++ b/resources/accessible-image-fr.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-image.html
+++ b/resources/accessible-image.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-meeting-event-guidelines-en.html
+++ b/resources/accessible-meeting-event-guidelines-en.html
@@ -14,8 +14,8 @@
         content="Proper planning of meetings and events is essential for the inclusion of all. There are several things to consider in the to-do list before and during these.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-meeting-event-guidelines-fr.html
+++ b/resources/accessible-meeting-event-guidelines-fr.html
@@ -13,8 +13,8 @@
         content="Une bonne planification des r&eacute;unions et des &eacute;v&eacute;nements est essentielle pour l&rsquo;inclusion de tous. Plusieurs &eacute;l&eacute;ments doivent être consid&eacute;r&eacute;s dans la liste de choses à faire avant et pendant ceux-ci.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-procurement-en.html
+++ b/resources/accessible-procurement-en.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-procurement-faq-en.html
+++ b/resources/accessible-procurement-faq-en.html
@@ -13,8 +13,8 @@
         content="Accessible Information and Communication Technology (ICT) Procurement Frequently Asked Questions">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-procurement-faq-fr.html
+++ b/resources/accessible-procurement-faq-fr.html
@@ -13,8 +13,8 @@
         content="Les logiciels commerciaux sont prêts à l’emploi et peuvent être achetés sur le marché; ils doivent être accessibles aux personnes handicapées pour leur permettre d’exécuter leurs tâches quotidiennes.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-procurement-fr.html
+++ b/resources/accessible-procurement-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-procurement-guidelines-en.html
+++ b/resources/accessible-procurement-guidelines-en.html
@@ -13,8 +13,8 @@
         content="Accessible Information and Communication Technology (ICT) Procurement Frequently Asked Questions">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-procurement-guidelines-fr.html
+++ b/resources/accessible-procurement-guidelines-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-software-en.html
+++ b/resources/accessible-software-en.html
@@ -13,8 +13,8 @@
         content="Commercial off the shelf (COTS) software are ready-made and available for purchase in the commercial market and they must be accessible for people with disabilities to perform their daily tasks.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-software-fr.html
+++ b/resources/accessible-software-fr.html
@@ -13,8 +13,8 @@
         content="Les logiciels commerciaux sont prêts à l’emploi et peuvent être achetés sur le marché; ils doivent être accessibles aux personnes handicapées pour leur permettre d’exécuter leurs tâches quotidiennes.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/accessible-web-pages-en.html
+++ b/resources/accessible-web-pages-en.html
@@ -16,8 +16,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 	</head>

--- a/resources/accessible-web-pages-fr.html
+++ b/resources/accessible-web-pages-fr.html
@@ -17,8 +17,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 	</head>

--- a/resources/additional-resources-en.html
+++ b/resources/additional-resources-en.html
@@ -14,8 +14,8 @@
         content="For more information on accessible meetings and events, you can consult this list of links.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/additional-resources-fr.html
+++ b/resources/additional-resources-fr.html
@@ -13,8 +13,8 @@
         content="Pour de plus amples informations sur les réunions et les événements accessibles, vous pouvez consulter cette liste de liens.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/anxiety-en.html
+++ b/resources/anxiety-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/anxiety-fr.html
+++ b/resources/anxiety-fr.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/at-lists-en.html
+++ b/resources/at-lists-en.html
@@ -13,8 +13,8 @@
         content="Below is a list of just some of the adaptive technology we have available for employees to use at Employment and Social Development Canada (ESDC), which is supported by our Accessibility Centre Expertise team.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/at-lists-fr.html
+++ b/resources/at-lists-fr.html
@@ -13,8 +13,8 @@
         content="Voici une liste de quelques-unes des technologies d'adaptation que nous mettons à la disposition des employés d'Emploi et Développement social Canada (EDSC), avec le soutien de notre équipe du Centre d'excellence en accessibilité.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/autistic-en.html
+++ b/resources/autistic-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/autistic-fr.html
+++ b/resources/autistic-fr.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/best-practices-excel-en.html
+++ b/resources/best-practices-excel-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/best-practices-excel-fr.html
+++ b/resources/best-practices-excel-fr.html
@@ -14,8 +14,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/best-practices-outlook-en.html
+++ b/resources/best-practices-outlook-en.html
@@ -13,8 +13,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/best-practices-outlook-fr.html
+++ b/resources/best-practices-outlook-fr.html
@@ -16,8 +16,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/best-practices-powerpoint-en.html
+++ b/resources/best-practices-powerpoint-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/best-practices-powerpoint-fr.html
+++ b/resources/best-practices-powerpoint-fr.html
@@ -14,8 +14,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/best-practices-word-en.html
+++ b/resources/best-practices-word-en.html
@@ -13,8 +13,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/best-practices-word-fr.html
+++ b/resources/best-practices-word-fr.html
@@ -14,8 +14,8 @@
     <meta name="description" content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/bookmarks-fr.html
+++ b/resources/bookmarks-fr.html
@@ -14,8 +14,8 @@
     <meta name="description" content="Cette page contient une liste des principaux liens et contacts du Bureau d'accessibilité aux technologies de l'information de l'ESDC.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/bookmarks.html
+++ b/resources/bookmarks.html
@@ -12,8 +12,8 @@
 	<meta name="description" content="This page contains a lists containing key links and contacts for ESDC's IT Accessibility Office.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../scripts/refTop.min.js"></script>
 

--- a/resources/deaf-hard-of-hearing-en.html
+++ b/resources/deaf-hard-of-hearing-en.html
@@ -14,8 +14,8 @@
         content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/deaf-hard-of-hearing-fr.html
+++ b/resources/deaf-hard-of-hearing-fr.html
@@ -14,8 +14,8 @@
         content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieI installed u du travail.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/dyslexia-en.html
+++ b/resources/dyslexia-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/dyslexia-fr.html
+++ b/resources/dyslexia-fr.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/events-en.html
+++ b/resources/events-en.html
@@ -14,8 +14,8 @@
 		content="In order to assist you in offering a fully accessible event (virtual or in person), weather it is a training session, a meeting, a kiosk or an open door event, the IT Accessibility Office (ITAO) has gathered the most relevant information on the subject.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/events-fr.html
+++ b/resources/events-fr.html
@@ -13,8 +13,8 @@
         content="Afin que vous puissiez offrir un &eacute;v&eacute;nement accessible (virtuel ou en personne) que ce soit de la formation, une r&eacute;union, un kiosk ou une porte-ouverte, le bureau de l&rsquo;accessibilit&eacute; des TI (BATI) a rassembl&eacute; l&rsquo;information la plus pertinente sur le sujet.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/examples/index-fr.html
+++ b/resources/examples/index-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/resources/examples/index.html
+++ b/resources/examples/index.html
@@ -15,8 +15,8 @@
         <meta name="robots" content="noindex, nofollow" />  
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/resources/examples/texthighlight-en.html
+++ b/resources/examples/texthighlight-en.html
@@ -15,8 +15,8 @@
         <meta name="robots" content="noindex, nofollow" />  
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/resources/examples/texthighlight-fr.html
+++ b/resources/examples/texthighlight-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/resources/faq-web-accessibility-en.html
+++ b/resources/faq-web-accessibility-en.html
@@ -16,8 +16,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 	</head>

--- a/resources/faq-web-accessibility-fr.html
+++ b/resources/faq-web-accessibility-fr.html
@@ -16,8 +16,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<!-- Write closure template -->
 		<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 	</head>

--- a/resources/index-fr.html
+++ b/resources/index-fr.html
@@ -13,8 +13,8 @@
         content="Cette page contient une myriade de listes et d'informations relatives à divers aspects de l'accessibilité (logiciels, conformité, conception, etc.). Inspectez chaque section pour trouver du contenu pertinent qui peuvent répondre à vos besoins ou intérêts.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/index.html
+++ b/resources/index.html
@@ -13,8 +13,8 @@
 		content="This page contains a myriad of lists and information pertaining to various aspects of accessibility (software, compliance, design, etc.). Inspect each section to find any pertinent content to your needs or interests.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/introduction-accessibility-en.html
+++ b/resources/introduction-accessibility-en.html
@@ -16,8 +16,8 @@
     to reference material that, we hope, will help you understand the concept of accessibility.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/introduction-accessibility-fr.html
+++ b/resources/introduction-accessibility-fr.html
@@ -13,8 +13,8 @@
         content="L’accessibilité est un sujet vaste et complexe qui nécessite de la formation et de la mise en application pour être maîtrisé, mais c’est un sujet important pour quiconque doit créer des documents, des courriels, des formulaires électroniques, des pages Web ou des applications de bureau. En incluant l’accessibilité dans la conception de votre travail, vous vous assurez que tout le monde peut participer pleinement. Voici quelques liens vers des documents de référence qui, nous l’espérons, vous aideront à comprendre le concept d’accessibilité.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/low-vision-en.html
+++ b/resources/low-vision-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/low-vision-fr.html
+++ b/resources/low-vision-fr.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/meeting-checklist-en.html
+++ b/resources/meeting-checklist-en.html
@@ -14,8 +14,8 @@
         content="In order to assist you in offering a fully accessible event (virtual or in person), weather it is a training session, a meeting, a kiosk or an open door event, the IT Accessibility Office (ITAO) has gathered the most relevant information on the subject.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/meeting-hearing-loss-en.html
+++ b/resources/meeting-hearing-loss-en.html
@@ -13,8 +13,8 @@
     <meta name="description" content="Accessible meetings and events for people with hearing loss.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/meeting-hearing-loss-fr.html
+++ b/resources/meeting-hearing-loss-fr.html
@@ -14,8 +14,8 @@
     <meta name="description" content="Des r&eacute;unions et des &eacute;v&eacute;nements accessibles aux personnes ayant une perte auditive">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/microsoft-forms-polls-best-practices-fr.html
+++ b/resources/microsoft-forms-polls-best-practices-fr.html
@@ -13,8 +13,8 @@
     <meta name="description" content="Nos conseils pour les organisateurs de réunions qui souhaitent une réunion interactive. Nous proposons des options de produits à utiliser et des moyens de rendre le contenu agréable pour tous.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/microsoft-forms-polls-best-practices.html
+++ b/resources/microsoft-forms-polls-best-practices.html
@@ -14,8 +14,8 @@
 		content="Our tips for meeting planners who want an interactive meeting. We give options for products to use and ways you can make the content enjoyable by everyone.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/microsoft-teams-en.html
+++ b/resources/microsoft-teams-en.html
@@ -15,8 +15,8 @@
             content="">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
       </head>

--- a/resources/microsoft-teams-fr.html
+++ b/resources/microsoft-teams-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/motor-disabilities-en.html
+++ b/resources/motor-disabilities-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/motor-disabilities-fr.html
+++ b/resources/motor-disabilities-fr.html
@@ -15,8 +15,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/ms-doc-compliance-checklist-en.html
+++ b/resources/ms-doc-compliance-checklist-en.html
@@ -18,8 +18,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../scripts/refTop.min.js"></script>
 	</head>

--- a/resources/ms-doc-compliance-checklist-fr.html
+++ b/resources/ms-doc-compliance-checklist-fr.html
@@ -13,8 +13,8 @@
         content="Vous trouverez ci-dessous des questions qui vous indiqueront si votre document Microsoft Office est accessible. Les critères de réussite renvoient aux Règles pour l’accessibilité des contenus Web (WCAG) 2.1 et le Guide de rédaction du contenu du site Canada.ca.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/pdf-accessibility-checklist-en.html
+++ b/resources/pdf-accessibility-checklist-en.html
@@ -14,8 +14,8 @@
         content="Below are questions that will help you establish if your Microsoft Office document is accessible. We provide the Success Criteria in reference with WCAG 2.1: How to Meet WCAG - Quick Reference and the Canada.ca Content Style Guide.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/pdf-accessibility-checklist-fr.html
+++ b/resources/pdf-accessibility-checklist-fr.html
@@ -15,8 +15,8 @@
         content="Vous trouverez ci-dessous des questions qui vous indiqueront si votre document Microsoft Office est accessible. Les critères de réussite renvoient aux Règles pour l’accessibilité des contenus Web (WCAG) 2.1 : How to Meet WCAG - Quick Reference (disponible en anglais seulement) et le Guide de rédaction du contenu du site Canada.ca.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/proposed-meeting-types-accessibility-features-en.html
+++ b/resources/proposed-meeting-types-accessibility-features-en.html
@@ -14,8 +14,8 @@
 		content="Here are our recommendations for choosing virtual meeting platforms based on the type of meeting or event, number of people, and content shared.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/proposed-meeting-types-accessibility-features-fr.html
+++ b/resources/proposed-meeting-types-accessibility-features-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/screen-reader-en.html
+++ b/resources/screen-reader-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/screen-reader-fr.html
+++ b/resources/screen-reader-fr.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/screen-reader-tips-for-virtual-meetings-fr.html
+++ b/resources/screen-reader-tips-for-virtual-meetings-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/screen-reader-tips-for-virtual-meetings.html
+++ b/resources/screen-reader-tips-for-virtual-meetings.html
@@ -15,8 +15,8 @@
             content=".">
          <!-- Meta data-->
          <!-- Load closure template scripts -->
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-         <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+         <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
          <!-- Write closure template -->
          <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
       </head>

--- a/resources/sign-language-view-microsoft-teams-en.html
+++ b/resources/sign-language-view-microsoft-teams-en.html
@@ -14,8 +14,8 @@
 		content="The Sign Language View is an option designed to help signers, sign language interpreters, and any one else who use sign language in a Teams meeting.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/sign-language-view-microsoft-teams-fr.html
+++ b/resources/sign-language-view-microsoft-teams-fr.html
@@ -13,8 +13,8 @@
         content="L'affichage en option est conçu pour aider les interprètes de la langue des signes et toute autre personne qui utilise la langue des signes durant une réunion Teams.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/virtual-meeting-platforms-accessibility-features-en.html
+++ b/resources/virtual-meeting-platforms-accessibility-features-en.html
@@ -14,8 +14,8 @@
 		content="Microsoft Teams and Zoom virtual meeting platforms offer a variety of accessibility features that meet different needs, including for meetings and chats.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 	<!-- Write closure template -->
 	<script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/virtual-meeting-platforms-accessibility-features-fr.html
+++ b/resources/virtual-meeting-platforms-accessibility-features-fr.html
@@ -13,8 +13,8 @@
         content="Les plateformes de réunions virtuelles Microsoft Teams et Zoom offrent diverses fonctionnalités d’accessibilité qui répondent à différents besoins, entre autres pour les réunions et les conversations.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/resources/wcag-en.html
+++ b/resources/wcag-en.html
@@ -14,8 +14,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/wcag-fr.html
+++ b/resources/wcag-fr.html
@@ -13,8 +13,8 @@
         content="">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/zoom-a11y-en.html
+++ b/resources/zoom-a11y-en.html
@@ -13,8 +13,8 @@
         content="Information on ways to use Zoom in an accessible way for remote meetings and classes.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <link rel="stylesheet" href="../css/style.css">
     <script src="../scripts/refTop.min.js"></script>

--- a/resources/zoom-a11y-fr.html
+++ b/resources/zoom-a11y-fr.html
@@ -13,8 +13,8 @@
         content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieI installed u du travail.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/resources/zoom-ux-en.html
+++ b/resources/zoom-ux-en.html
@@ -13,8 +13,8 @@
         content="Tips on how to improve the user experience in Zoom.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <link rel="stylesheet" href="../css/style.css">
     <script src="../scripts/refTop.min.js"></script>

--- a/services/_template-en.html
+++ b/services/_template-en.html
@@ -13,8 +13,8 @@
         content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/services/_template-fr.html
+++ b/services/_template-fr.html
@@ -13,8 +13,8 @@
         content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieu du travail.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/services/accessibility-advice-compliance-en.html
+++ b/services/accessibility-advice-compliance-en.html
@@ -16,8 +16,8 @@
         assistance in locating the services you require.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="https://bati-itao.github.io/scripts/refTop.min.js"></script>
 </head>

--- a/services/accessibility-advice-compliance-fr.html
+++ b/services/accessibility-advice-compliance-fr.html
@@ -17,8 +17,8 @@
         trouver les services dont vous avez besoin.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/blindness-en.html
+++ b/services/commun-types-disability/blindness-en.html
@@ -13,8 +13,8 @@
         content="People who are blind have a range of conditions from severely reduced visual acuity to complete loss of vision and light perception. A variety of software and hardware is used to provide accommodations for employees who are blind.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/blindness-fr.html
+++ b/services/commun-types-disability/blindness-fr.html
@@ -14,8 +14,8 @@
         content="Les personnes aveugles présentent des conditions allant de sévère réduction de l'acuité visuelle à la perte totale de vision et de perception de la lumière. Une variété de logiciels et d'équipements sont utilisés afin d'offrir des mesures d'adaptation aux employés aveugles.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/cognition-en.html
+++ b/services/commun-types-disability/cognition-en.html
@@ -14,8 +14,8 @@
         content="Cognitive impairments take many forms, including short and long-term memory impairments, and perceptual differences. Language impairments, including dyslexia and temporary impairments associated with those attempting to learn new languages, are also common cognitive problems. Normally a combination of adaptive computer technologies is used to help people with cognition problems.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/cognition-fr.html
+++ b/services/commun-types-disability/cognition-fr.html
@@ -14,8 +14,8 @@
         content="On trouve une vaste gamme de déficience cognitive, telle que l'affaiblissement de la mémoire à court et à long terme et la différence perceptuelle. Les problèmes de langage, tels que la dyslexie et les difficultés temporaires qu'éprouvent les personnes qui apprennent de nouvelles langues, constituent également des problèmes cognitifs courants. Habituellement, une combinaison de TIA est salutaire aux personnes aux prises avec des problèmes cognitifs.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/deafness-en.html
+++ b/services/commun-types-disability/deafness-en.html
@@ -14,8 +14,8 @@
         content='The term "hearing impaired" describes people with any degree of hearing loss, from mild to profound, including those who are deaf and those who are hard of hearing.'>
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/deafness-fr.html
+++ b/services/commun-types-disability/deafness-fr.html
@@ -14,8 +14,8 @@
         content="Le terme « déficience auditive » décrit les personnes ayant tout degré de perte auditive, de légère à profonde, y compris les personnes sourdes ainsi que les personnes malentendantes.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/index-fr.html
+++ b/services/commun-types-disability/index-fr.html
@@ -13,8 +13,8 @@
         content="Le bureau de l'accessibilite des TI est fournisseur de technologie adaptative et l'avocat pour l'inclusion des personnes ayant des handicaps dans le lieu du travail.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/index.html
+++ b/services/commun-types-disability/index.html
@@ -13,8 +13,8 @@
         content="IT Accessibility Office provides adaptive technology and advocate for inclusiveness of people with disabilities in the workplace.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/low-vision-en.html
+++ b/services/commun-types-disability/low-vision-en.html
@@ -14,8 +14,8 @@
         content="People with low vision have sight problems that range from slightly reduced visual acuity to close to total blindness. This may require changes to their desktop area or add-on equipment that helps magnify the images on the screen.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/low-vision-fr.html
+++ b/services/commun-types-disability/low-vision-fr.html
@@ -14,8 +14,8 @@
         content="Une personne ayant une basse vision souffre de problèmes allant d'une légère réduction de l'acuité visuelle à la cécité totale. Un employé à l'acuité visuelle réduite n'a peut-être besoin que images à l'écran d'ordinateur de taille raisonnable ou qu'elles soient agrandies. Aussi, faudra-t-il sans doute apporter des modifications à l'endroit où se trouve son ordinateur de bureau ou lui fournir des appareils complémentaires qui agrandiront l'image à l'écran.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/mobility-dexterity-en.html
+++ b/services/commun-types-disability/mobility-dexterity-en.html
@@ -13,8 +13,8 @@
         content="Mobility/dexterity impairments range from problems stemming from musculoskeletal disorders such as carpal tunnel syndrome or back pain, to little or no use of one or both hands. Individuals with these impairments may require special devices to use computer equipment, including modified keyboards, on-screen keyboards or a head or foot mouse. They may also need to use word prediction or voice recognition systems to help them type.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/commun-types-disability/mobility-dexterity-fr.html
+++ b/services/commun-types-disability/mobility-dexterity-fr.html
@@ -13,8 +13,8 @@
 	<meta name="description" content="Les troubles de mobilité ou de dextérité couvrent une gamme de problèmes, allant de ceux découlant de troubles musculosquelettiques, tels que le syndrome du tunnel carpien et les maux de dos, à la perte de l'usage presque complète ou complète d'une main. L'employé souffrant de l'un de ces troubles peut avoir besoin d'appareils particuliers lui permettant d'utiliser un ordinateur, tels que clavier modifié, souris commandée par la tête ou le pied. Il peut également avoir besoin d'un système de prédiction de mots ou de reconnaissance vocale qui l'aidera à la saisie de texte.">
 	<!-- Meta data-->
 	<!-- Load closure template scripts -->
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-	<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+	<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 	<!-- Write closure template -->
 	<script src="../../scripts/refTop.min.js"></script>
 </head>

--- a/services/index-fr.html
+++ b/services/index-fr.html
@@ -13,8 +13,8 @@
         content="Ces services comprennent le soutien, l'encadrement et l'évaluation de produits de la technologie adaptative (TA).">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/services/index.html
+++ b/services/index.html
@@ -13,8 +13,8 @@
         content="These services include adaptive technology support, coaching and product assessments.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/services/service-standards-en.html
+++ b/services/service-standards-en.html
@@ -15,8 +15,8 @@
         responding to service requests within the prescribed Service Delivery Standards provided below.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/services/service-standards-fr.html
+++ b/services/service-standards-fr.html
@@ -16,8 +16,8 @@
         des normes de livraison de service prescrites ici-bas.">
     <!-- Meta data-->
     <!-- Load closure template scripts -->
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-    <script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
     <!-- Write closure template -->
     <script src="../scripts/refTop.min.js"></script>
 </head>

--- a/teams/svatic-ictaas/index-en.html
+++ b/teams/svatic-ictaas/index-en.html
@@ -20,8 +20,8 @@
 		/>
 		<!-- Meta data-->
 		<!-- Load closure template scripts -->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-en.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/style.css" />

--- a/teams/svatic-ictaas/index-fr.html
+++ b/teams/svatic-ictaas/index-fr.html
@@ -21,8 +21,8 @@
       des handicaps dans le lieu du travail."
 		/>
 		<!-- Meta data-->
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/soyutils.js"></script>
-		<script src="https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/compiled/wet-fr.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/compiled/wet-fr.js"></script>
 		<script src="../../scripts/refTop.min.js"></script>
 		<link rel="stylesheet" href="../../css/style.css" />
 		<link rel="stylesheet" href="../styles/custom.css" />


### PR DESCRIPTION
Global replaced this
https://ssl-templates.services.gc.ca/rn/cls/wet/gcweb/cdts/

to this
https://www.canada.ca/etc/designs/canada/cdts/gcweb/rn/cdts/

1008 changes over 504 files